### PR TITLE
Add Ansible roles for host hardening and container runtimes

### DIFF
--- a/roles/docker_host/defaults/main.yml
+++ b/roles/docker_host/defaults/main.yml
@@ -1,0 +1,5 @@
+---
+docker_host_users: []  # list of usernames to add to docker group
+docker_host_enable_service: true
+docker_host_daemon_config: {}
+docker_host_compose_version: latest

--- a/roles/docker_host/handlers/main.yml
+++ b/roles/docker_host/handlers/main.yml
@@ -1,0 +1,6 @@
+---
+- name: Restart docker
+  ansible.builtin.systemd:
+    name: docker
+    state: restarted
+  when: ansible_service_mgr == 'systemd'

--- a/roles/docker_host/tasks/common.yml
+++ b/roles/docker_host/tasks/common.yml
@@ -1,0 +1,50 @@
+---
+- name: Ensure docker group exists
+  ansible.builtin.group:
+    name: docker
+    state: present
+
+- name: Add users to docker group
+  ansible.builtin.user:
+    name: "{{ item }}"
+    groups: docker
+    append: true
+  loop: "{{ docker_host_users }}"
+  when: docker_host_users | length > 0
+
+- name: Configure Docker daemon JSON when specified
+  ansible.builtin.copy:
+    dest: /etc/docker/daemon.json
+    content: "{{ docker_host_daemon_config | to_nice_json(indent=2) }}\n"
+    owner: root
+    group: root
+    mode: '0644'
+  when: docker_host_daemon_config | length > 0
+  notify: Restart docker
+
+- name: Ensure docker service is enabled on systemd hosts
+  ansible.builtin.systemd:
+    name: docker
+    state: started
+    enabled: true
+  when:
+    - docker_host_enable_service
+    - ansible_service_mgr == 'systemd'
+
+- name: Check for docker compose plugin
+  ansible.builtin.stat:
+    path: /usr/libexec/docker/cli-plugins/docker-compose
+  register: docker_compose_plugin
+  when: ansible_os_family == 'RedHat'
+
+- name: Enable docker-compose compatibility symlink when needed
+  ansible.builtin.file:
+    src: /usr/libexec/docker/cli-plugins/docker-compose
+    dest: /usr/local/bin/docker-compose
+    state: link
+  when:
+    - ansible_os_family == 'RedHat'
+    - docker_host_enable_service
+    - docker_compose_plugin is defined
+    - docker_compose_plugin.stat.exists
+

--- a/roles/docker_host/tasks/debian.yml
+++ b/roles/docker_host/tasks/debian.yml
@@ -1,0 +1,40 @@
+---
+- name: Ensure apt prerequisites are present
+  ansible.builtin.apt:
+    name: "{{ docker_host_prereq_packages.get(ansible_distribution, docker_host_prereq_packages.get(ansible_os_family, [])) }}"
+    state: present
+    update_cache: true
+
+- name: Create docker apt key directory
+  ansible.builtin.file:
+    path: /etc/apt/keyrings
+    state: directory
+    mode: '0755'
+
+- name: Determine Docker repository architecture label
+  ansible.builtin.set_fact:
+    docker_host_arch: "{{ 'arm64' if ansible_architecture in ['aarch64', 'arm64'] else 'amd64' }}"
+
+- name: Install Docker repository GPG key
+  ansible.builtin.get_url:
+    url: "https://download.docker.com/linux/{{ ansible_distribution | lower }}/gpg"
+    dest: /etc/apt/keyrings/docker.gpg
+    mode: '0644'
+
+- name: Configure Docker APT repository
+  ansible.builtin.copy:
+    dest: /etc/apt/sources.list.d/docker.list
+    content: |
+      deb [arch={{ docker_host_arch }} signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/{{ ansible_distribution | lower }} {{ ansible_distribution_release | lower }} stable
+    owner: root
+    group: root
+    mode: '0644'
+
+- name: Update apt cache for Docker packages
+  ansible.builtin.apt:
+    update_cache: true
+
+- name: Install Docker engine components
+  ansible.builtin.apt:
+    name: "{{ docker_host_package_map.get(ansible_distribution, docker_host_package_map.get(ansible_os_family, [])) }}"
+    state: present

--- a/roles/docker_host/tasks/main.yml
+++ b/roles/docker_host/tasks/main.yml
@@ -1,0 +1,11 @@
+---
+- name: Include Debian family setup
+  ansible.builtin.include_tasks: debian.yml
+  when: ansible_os_family == 'Debian'
+
+- name: Include Red Hat family setup
+  ansible.builtin.include_tasks: redhat.yml
+  when: ansible_os_family == 'RedHat'
+
+- name: Include common Docker configuration
+  ansible.builtin.import_tasks: common.yml

--- a/roles/docker_host/tasks/redhat.yml
+++ b/roles/docker_host/tasks/redhat.yml
@@ -1,0 +1,25 @@
+---
+- name: Ensure Docker prerequisites present on Red Hat hosts
+  ansible.builtin.dnf:
+    name: "{{ docker_host_prereq_packages.get(ansible_distribution, docker_host_prereq_packages.get('AlmaLinux', [])) }}"
+    state: present
+    update_cache: true
+
+- name: Configure Docker CE repository
+  ansible.builtin.get_url:
+    url: https://download.docker.com/linux/centos/docker-ce.repo
+    dest: /etc/yum.repos.d/docker-ce.repo
+    mode: '0644'
+
+- name: Install Docker engine packages
+  ansible.builtin.dnf:
+    name: "{{ docker_host_package_map.get(ansible_distribution, docker_host_package_map.get('AlmaLinux', [])) }}"
+    state: present
+    enablerepo: docker-ce-stable
+
+- name: Ensure docker service is enabled
+  ansible.builtin.systemd:
+    name: docker
+    state: started
+    enabled: true
+  when: docker_host_enable_service

--- a/roles/docker_host/vars/main.yml
+++ b/roles/docker_host/vars/main.yml
@@ -1,0 +1,35 @@
+---
+docker_host_prereq_packages:
+  Debian:
+    - ca-certificates
+    - curl
+    - gnupg
+    - lsb-release
+  Ubuntu:
+    - ca-certificates
+    - curl
+    - gnupg
+    - lsb-release
+  AlmaLinux:
+    - yum-utils
+    - device-mapper-persistent-data
+    - lvm2
+docker_host_package_map:
+  Debian:
+    - docker-ce
+    - docker-ce-cli
+    - containerd.io
+    - docker-buildx-plugin
+    - docker-compose-plugin
+  Ubuntu:
+    - docker-ce
+    - docker-ce-cli
+    - containerd.io
+    - docker-buildx-plugin
+    - docker-compose-plugin
+  AlmaLinux:
+    - docker-ce
+    - docker-ce-cli
+    - containerd.io
+    - docker-buildx-plugin
+    - docker-compose-plugin

--- a/roles/kubernetes_host/defaults/main.yml
+++ b/roles/kubernetes_host/defaults/main.yml
@@ -1,0 +1,9 @@
+---
+kubernetes_version: "1.29"
+kubernetes_cni_packages:
+  - containerd
+kubernetes_control_plane: false
+kubernetes_sysctl_settings:
+  - { name: 'net.bridge.bridge-nf-call-iptables', value: '1' }
+  - { name: 'net.bridge.bridge-nf-call-ip6tables', value: '1' }
+  - { name: 'net.ipv4.ip_forward', value: '1' }

--- a/roles/kubernetes_host/handlers/main.yml
+++ b/roles/kubernetes_host/handlers/main.yml
@@ -1,0 +1,12 @@
+---
+- name: Restart containerd
+  ansible.builtin.systemd:
+    name: containerd
+    state: restarted
+  when: ansible_service_mgr == 'systemd'
+
+- name: Restart kubelet
+  ansible.builtin.systemd:
+    name: kubelet
+    state: restarted
+  when: ansible_service_mgr == 'systemd'

--- a/roles/kubernetes_host/tasks/common.yml
+++ b/roles/kubernetes_host/tasks/common.yml
@@ -1,0 +1,102 @@
+---
+- name: Disable swap immediately
+  ansible.builtin.command: swapoff -a
+  changed_when: false
+  failed_when: false
+
+- name: Comment swap entries in fstab
+  ansible.builtin.replace:
+    path: /etc/fstab
+    regexp: '^([^#].*\sswap\s.*)$'
+    replace: '# \1'
+  register: swap_comment
+  notify: Restart kubelet
+  failed_when: false
+
+- name: Ensure kernel modules are loaded
+  ansible.builtin.copy:
+    dest: /etc/modules-load.d/kubernetes.conf
+    content: |
+      overlay
+      br_netfilter
+    owner: root
+    group: root
+    mode: '0644'
+  notify: Restart containerd
+
+- name: Load overlay module
+  ansible.builtin.modprobe:
+    name: overlay
+    state: present
+
+- name: Load br_netfilter module
+  ansible.builtin.modprobe:
+    name: br_netfilter
+    state: present
+
+- name: Apply Kubernetes sysctl settings
+  ansible.builtin.sysctl:
+    name: "{{ item.name }}"
+    value: "{{ item.value }}"
+    sysctl_set: true
+    reload: true
+  loop: "{{ kubernetes_sysctl_settings }}"
+
+- name: Ensure containerd configuration directory exists
+  ansible.builtin.file:
+    path: /etc/containerd
+    state: directory
+    mode: '0755'
+
+- name: Check for existing containerd configuration
+  ansible.builtin.stat:
+    path: /etc/containerd/config.toml
+  register: containerd_config
+  when: ansible_facts.packages.get('containerd') is defined or 'containerd' in kubernetes_cni_packages
+
+- name: Generate default containerd configuration
+  ansible.builtin.command: containerd config default
+  register: containerd_default_config
+  changed_when: containerd_default_config.rc == 0
+  when:
+    - containerd_config is defined
+    - not containerd_config.stat.exists
+
+- name: Write containerd configuration to disk
+  ansible.builtin.copy:
+    dest: /etc/containerd/config.toml
+    content: "{{ containerd_default_config.stdout }}\n"
+    owner: root
+    group: root
+    mode: '0644'
+  when: containerd_default_config is defined
+  notify: Restart containerd
+
+- name: Mark containerd configuration as present
+  ansible.builtin.set_fact:
+    containerd_config:
+      stat:
+        exists: true
+  when: containerd_default_config is defined
+
+- name: Ensure containerd uses systemd cgroups
+  ansible.builtin.replace:
+    path: /etc/containerd/config.toml
+    regexp: 'SystemdCgroup = false'
+    replace: 'SystemdCgroup = true'
+  notify: Restart containerd
+  when: containerd_config is defined and containerd_config.stat.exists
+
+- name: Enable containerd service
+  ansible.builtin.systemd:
+    name: containerd
+    state: started
+    enabled: true
+  when: ansible_service_mgr == 'systemd'
+
+- name: Enable kubelet service
+  ansible.builtin.systemd:
+    name: kubelet
+    enabled: true
+    state: started
+  when: ansible_service_mgr == 'systemd'

--- a/roles/kubernetes_host/tasks/debian.yml
+++ b/roles/kubernetes_host/tasks/debian.yml
@@ -1,0 +1,56 @@
+---
+- name: Install Kubernetes prerequisites on Debian family
+  ansible.builtin.apt:
+    name:
+      - apt-transport-https
+      - ca-certificates
+      - curl
+      - gnupg
+    state: present
+    update_cache: true
+
+- name: Ensure apt key directory exists
+  ansible.builtin.file:
+    path: /etc/apt/keyrings
+    state: directory
+    mode: '0755'
+
+- name: Download Kubernetes Release key
+  ansible.builtin.get_url:
+    url: "{{ kubernetes_repo_base.get(ansible_distribution, kubernetes_repo_base.get(ansible_os_family, '')) }}Release.key"
+    dest: /etc/apt/keyrings/kubernetes-release.key
+    mode: '0644'
+
+- name: Convert Kubernetes key to keyring format
+  ansible.builtin.command: gpg --dearmor --yes -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg /etc/apt/keyrings/kubernetes-release.key
+  args:
+    creates: /etc/apt/keyrings/kubernetes-apt-keyring.gpg
+
+- name: Configure Kubernetes apt repository
+  ansible.builtin.copy:
+    dest: /etc/apt/sources.list.d/kubernetes.list
+    content: |
+      deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] {{ kubernetes_repo_base.get(ansible_distribution, kubernetes_repo_base.get(ansible_os_family, '')) }} /
+    owner: root
+    group: root
+    mode: '0644'
+
+- name: Update apt cache for Kubernetes packages
+  ansible.builtin.apt:
+    update_cache: true
+
+- name: Install container runtime packages
+  ansible.builtin.apt:
+    name: "{{ kubernetes_cni_packages }}"
+    state: present
+
+- name: Install Kubernetes components
+  ansible.builtin.apt:
+    name: "{{ kubernetes_packages.get(ansible_distribution, kubernetes_packages.get(ansible_os_family, [])) }}"
+    state: present
+
+- name: Hold Kubernetes packages at current version
+  ansible.builtin.dpkg_selections:
+    name: "{{ item }}"
+    selection: hold
+  loop: "{{ kubernetes_packages.get(ansible_distribution, kubernetes_packages.get(ansible_os_family, [])) }}"

--- a/roles/kubernetes_host/tasks/main.yml
+++ b/roles/kubernetes_host/tasks/main.yml
@@ -1,0 +1,15 @@
+---
+- name: Gather package facts for Kubernetes role
+  ansible.builtin.package_facts:
+    manager: auto
+
+- name: Include Debian family Kubernetes setup
+  ansible.builtin.include_tasks: debian.yml
+  when: ansible_os_family == 'Debian'
+
+- name: Include Red Hat family Kubernetes setup
+  ansible.builtin.include_tasks: redhat.yml
+  when: ansible_os_family == 'RedHat'
+
+- name: Apply common Kubernetes host configuration
+  ansible.builtin.import_tasks: common.yml

--- a/roles/kubernetes_host/tasks/redhat.yml
+++ b/roles/kubernetes_host/tasks/redhat.yml
@@ -1,0 +1,45 @@
+---
+- name: Install Kubernetes prerequisites on Red Hat family
+  ansible.builtin.dnf:
+    name:
+      - curl
+      - gnupg2
+      - iptables
+      - ebtables
+    state: present
+    update_cache: true
+
+- name: Enable Kubernetes repository gpg key
+  ansible.builtin.get_url:
+    url: "{{ kubernetes_repo_base.get(ansible_distribution, kubernetes_repo_base.get('AlmaLinux')) }}repodata/repomd.xml.key"
+    dest: /etc/pki/rpm-gpg/RPM-GPG-KEY-kubernetes
+    mode: '0644'
+
+- name: Import Kubernetes GPG key
+  ansible.builtin.rpm_key:
+    state: present
+    key: /etc/pki/rpm-gpg/RPM-GPG-KEY-kubernetes
+
+- name: Configure Kubernetes repository
+  ansible.builtin.copy:
+    dest: /etc/yum.repos.d/kubernetes.repo
+    content: |
+      [kubernetes]
+      name=Kubernetes
+      baseurl={{ kubernetes_repo_base.get(ansible_distribution, kubernetes_repo_base.get('AlmaLinux')) }}
+      enabled=1
+      gpgcheck=1
+      gpgkey={{ kubernetes_repo_base.get(ansible_distribution, kubernetes_repo_base.get('AlmaLinux')) }}repodata/repomd.xml.key
+    owner: root
+    group: root
+    mode: '0644'
+
+- name: Install container runtime packages
+  ansible.builtin.dnf:
+    name: "{{ kubernetes_cni_packages }}"
+    state: present
+
+- name: Install Kubernetes components
+  ansible.builtin.dnf:
+    name: "{{ kubernetes_packages.get(ansible_distribution, kubernetes_packages.get('AlmaLinux', [])) }}"
+    state: present

--- a/roles/kubernetes_host/vars/main.yml
+++ b/roles/kubernetes_host/vars/main.yml
@@ -1,0 +1,18 @@
+---
+kubernetes_packages:
+  Debian:
+    - kubelet
+    - kubeadm
+    - kubectl
+  Ubuntu:
+    - kubelet
+    - kubeadm
+    - kubectl
+  AlmaLinux:
+    - kubelet
+    - kubeadm
+    - kubectl
+kubernetes_repo_base:
+  Debian: https://pkgs.k8s.io/core:/stable:/v{{ kubernetes_version }}/deb/
+  Ubuntu: https://pkgs.k8s.io/core:/stable:/v{{ kubernetes_version }}/deb/
+  AlmaLinux: https://pkgs.k8s.io/core:/stable:/v{{ kubernetes_version }}/rpm/

--- a/roles/podman_host/defaults/main.yml
+++ b/roles/podman_host/defaults/main.yml
@@ -1,0 +1,14 @@
+---
+podman_host_user: podman
+podman_host_user_shell: /bin/bash
+podman_host_user_comment: Podman Service User
+podman_host_uid_range_start: 100000
+podman_host_uid_range_size: 65536
+podman_host_runtime_path: /usr/bin/podman
+podman_host_secure_wrapper_path: /usr/local/bin/secure-podman
+podman_host_log_dir: /var/log/containers
+podman_host_enable_firewalld: true
+podman_host_firewalld_zone: trusted
+podman_host_cron_minute: 0
+podman_host_cron_hour: 2
+podman_host_prune_command: /usr/bin/podman system prune -f

--- a/roles/podman_host/tasks/common.yml
+++ b/roles/podman_host/tasks/common.yml
@@ -1,0 +1,151 @@
+---
+- name: Ensure Podman service user exists
+  ansible.builtin.user:
+    name: "{{ podman_host_user }}"
+    comment: "{{ podman_host_user_comment }}"
+    shell: "{{ podman_host_user_shell }}"
+    create_home: true
+    password_lock: true
+
+- name: Add Podman user to systemd-journal group
+  ansible.builtin.user:
+    name: "{{ podman_host_user }}"
+    groups: systemd-journal
+    append: true
+  ignore_errors: true
+
+- name: Configure subuid allocation for Podman user
+  ansible.builtin.lineinfile:
+    path: /etc/subuid
+    create: true
+    line: "{{ podman_host_user }}:{{ podman_host_uid_range_start }}:{{ podman_host_uid_range_size }}"
+    state: present
+
+- name: Configure subgid allocation for Podman user
+  ansible.builtin.lineinfile:
+    path: /etc/subgid
+    create: true
+    line: "{{ podman_host_user }}:{{ podman_host_uid_range_start }}:{{ podman_host_uid_range_size }}"
+    state: present
+
+- name: Lookup Podman user UID
+  ansible.builtin.command: "id -u {{ podman_host_user }}"
+  register: podman_uid_lookup
+  changed_when: false
+
+- name: Set Podman UID fact
+  ansible.builtin.set_fact:
+    podman_host_uid: "{{ podman_uid_lookup.stdout | int }}"
+
+- name: Ensure Podman configuration directory exists
+  ansible.builtin.file:
+    path: "/home/{{ podman_host_user }}/.config/containers"
+    state: directory
+    owner: "{{ podman_host_user }}"
+    group: "{{ podman_host_user }}"
+    mode: '0750'
+
+- name: Deploy rootless containers configuration
+  ansible.builtin.template:
+    src: containers.conf.j2
+    dest: "/home/{{ podman_host_user }}/.config/containers/containers.conf"
+    owner: "{{ podman_host_user }}"
+    group: "{{ podman_host_user }}"
+    mode: '0640'
+
+- name: Deploy rootless storage configuration
+  ansible.builtin.template:
+    src: storage.conf.j2
+    dest: "/home/{{ podman_host_user }}/.config/containers/storage.conf"
+    owner: "{{ podman_host_user }}"
+    group: "{{ podman_host_user }}"
+    mode: '0640'
+
+- name: Deploy container policy configuration
+  ansible.builtin.template:
+    src: policy.json.j2
+    dest: /etc/containers/policy.json
+    owner: root
+    group: root
+    mode: '0644'
+
+- name: Ensure Podman log directory exists
+  ansible.builtin.file:
+    path: "{{ podman_host_log_dir }}"
+    state: directory
+    owner: "{{ podman_host_user }}"
+    group: "{{ podman_host_user }}"
+    mode: '0750'
+
+- name: Install Podman security wrapper
+  ansible.builtin.template:
+    src: secure-podman.sh.j2
+    dest: "{{ podman_host_secure_wrapper_path }}"
+    owner: root
+    group: root
+    mode: '0755'
+
+- name: Ensure Podman runtime directory exists
+  ansible.builtin.file:
+    path: "/run/user/{{ podman_host_uid }}"
+    state: directory
+    owner: "{{ podman_host_user }}"
+    group: "{{ podman_host_user }}"
+    mode: '0700'
+
+- name: Configure tmpfiles entry for Podman runtime
+  ansible.builtin.template:
+    src: tmpfiles.conf.j2
+    dest: "/etc/tmpfiles.d/{{ podman_host_user }}.conf"
+    owner: root
+    group: root
+    mode: '0644'
+
+- name: Apply tmpfiles configuration
+  ansible.builtin.command: "systemd-tmpfiles --create /etc/tmpfiles.d/{{ podman_host_user }}.conf"
+  changed_when: false
+  failed_when: false
+
+- name: Enable lingering for Podman user
+  ansible.builtin.command: "loginctl enable-linger {{ podman_host_user }}"
+  args:
+    creates: "/var/lib/systemd/linger/{{ podman_host_user }}"
+  when: ansible_service_mgr == 'systemd'
+
+- name: Enable Podman socket for service user
+  ansible.builtin.systemd:
+    name: podman.socket
+    scope: user
+    state: started
+    enabled: true
+  become: true
+  become_user: "{{ podman_host_user }}"
+  environment:
+    XDG_RUNTIME_DIR: "/run/user/{{ podman_host_uid }}"
+  when: ansible_service_mgr == 'systemd'
+
+- name: Harden Podman home permissions
+  ansible.builtin.file:
+    path: "/home/{{ podman_host_user }}"
+    state: directory
+    owner: "{{ podman_host_user }}"
+    group: "{{ podman_host_user }}"
+    mode: '0700'
+
+- name: Ensure Podman containers configuration directory permissions
+  ansible.builtin.file:
+    path: "/home/{{ podman_host_user }}/.config/containers"
+    state: directory
+    owner: "{{ podman_host_user }}"
+    group: "{{ podman_host_user }}"
+    mode: '0750'
+    recurse: true
+
+- name: Configure weekly Podman cleanup cron job
+  ansible.builtin.cron:
+    name: Podman system prune
+    minute: "{{ podman_host_cron_minute }}"
+    hour: "{{ podman_host_cron_hour }}"
+    weekday: 0
+    job: "{{ podman_host_prune_command }}"
+    user: "{{ podman_host_user }}"

--- a/roles/podman_host/tasks/debian.yml
+++ b/roles/podman_host/tasks/debian.yml
@@ -1,0 +1,15 @@
+---
+- name: Update apt cache for Podman host
+  ansible.builtin.apt:
+    update_cache: true
+    cache_valid_time: 3600
+
+- name: Upgrade packages on Podman host
+  ansible.builtin.apt:
+    upgrade: dist
+    autoremove: true
+
+- name: Install Podman dependencies on Debian family
+  ansible.builtin.apt:
+    name: "{{ podman_host_packages.get(ansible_distribution, podman_host_packages.get(ansible_os_family, [])) }}"
+    state: present

--- a/roles/podman_host/tasks/main.yml
+++ b/roles/podman_host/tasks/main.yml
@@ -1,0 +1,7 @@
+---
+- name: Include operating system specific setup
+  ansible.builtin.include_tasks: "{{ 'debian.yml' if ansible_os_family == 'Debian' else 'redhat.yml' }}"
+  when: ansible_os_family in ['Debian', 'RedHat']
+
+- name: Include common Podman configuration
+  ansible.builtin.import_tasks: common.yml

--- a/roles/podman_host/tasks/redhat.yml
+++ b/roles/podman_host/tasks/redhat.yml
@@ -1,0 +1,47 @@
+---
+- name: Update packages on Podman host
+  ansible.builtin.dnf:
+    name: "*"
+    state: latest
+    update_cache: true
+
+- name: Install Podman dependencies on Red Hat family
+  ansible.builtin.dnf:
+    name: "{{ podman_host_packages.get(ansible_distribution, podman_host_packages.get('AlmaLinux', [])) }}"
+    state: present
+    disable_gpg_check: false
+
+- name: Ensure firewalld is installed for Podman networking
+  ansible.builtin.dnf:
+    name: firewalld
+    state: present
+
+- name: Enable firewalld for Podman hosts
+  ansible.builtin.systemd:
+    name: firewalld
+    state: started
+    enabled: true
+  when: podman_host_enable_firewalld
+
+- name: Permit Podman bridge interfaces through firewalld
+  ansible.posix.firewalld:
+    zone: "{{ podman_host_firewalld_zone }}"
+    state: enabled
+    interface: "{{ item }}"
+    permanent: true
+    immediate: true
+  loop:
+    - cni-podman0
+    - podman0
+  when: podman_host_enable_firewalld
+  ignore_errors: true
+
+- name: Allow masquerading for Podman networking
+  ansible.posix.firewalld:
+    zone: public
+    masquerade: true
+    state: enabled
+    permanent: true
+    immediate: true
+  when: podman_host_enable_firewalld
+  ignore_errors: true

--- a/roles/podman_host/templates/containers.conf.j2
+++ b/roles/podman_host/templates/containers.conf.j2
@@ -1,0 +1,6 @@
+[engine]
+runtime = "crun"
+cgroup_manager = "systemd"
+events_logger = "journald"
+log_driver = "k8s-file"
+[engine.runtimes]

--- a/roles/podman_host/templates/policy.json.j2
+++ b/roles/podman_host/templates/policy.json.j2
@@ -1,0 +1,16 @@
+{
+  "default": [
+    {
+      "type": "insecureAcceptAnything"
+    }
+  ],
+  "transports": {
+    "docker-daemon": {
+      "": [
+        {
+          "type": "insecureAcceptAnything"
+        }
+      ]
+    }
+  }
+}

--- a/roles/podman_host/templates/secure-podman.sh.j2
+++ b/roles/podman_host/templates/secure-podman.sh.j2
@@ -1,0 +1,6 @@
+#!/bin/sh
+if [ "$(id -u)" -eq 0 ]; then
+  printf "Error: Do not run containers as root!\n" >&2
+  exit 1
+fi
+exec "{{ podman_host_runtime_path }}" --log-level=info --syslog "$@"

--- a/roles/podman_host/templates/storage.conf.j2
+++ b/roles/podman_host/templates/storage.conf.j2
@@ -1,0 +1,8 @@
+[storage]
+driver = "overlay"
+runroot = "/run/user/{{ podman_host_uid }}/containers"
+graphroot = "/home/{{ podman_host_user }}/.local/share/containers/storage"
+[storage.options]
+additionalimagestores = []
+[storage.options.overlay]
+mount_program = "/usr/bin/fuse-overlayfs"

--- a/roles/podman_host/templates/tmpfiles.conf.j2
+++ b/roles/podman_host/templates/tmpfiles.conf.j2
@@ -1,0 +1,1 @@
+d /run/user/{{ podman_host_uid }} 0700 {{ podman_host_user }} {{ podman_host_user }} -

--- a/roles/podman_host/vars/main.yml
+++ b/roles/podman_host/vars/main.yml
@@ -1,0 +1,25 @@
+---
+podman_host_packages:
+  Debian:
+    - podman
+    - cockpit-podman
+    - uidmap
+    - slirp4netns
+    - fuse-overlayfs
+    - acl
+  Ubuntu:
+    - podman
+    - cockpit-podman
+    - uidmap
+    - slirp4netns
+    - fuse-overlayfs
+    - acl
+  AlmaLinux:
+    - podman
+    - cockpit-podman
+    - containers-common
+    - fuse-overlayfs
+    - slirp4netns
+    - acl
+    - shadow-utils
+    - shadow-utils-subid

--- a/roles/system_hardening/defaults/main.yml
+++ b/roles/system_hardening/defaults/main.yml
@@ -1,0 +1,42 @@
+---
+hardening_ssh_port: 6922
+hardening_authorized_users: []  # list of {name: user, key: ssh-rsa ...}
+hardening_fail2ban_maxretry: 3
+hardening_fail2ban_bantime: 3600
+hardening_fail2ban_findtime: 600
+hardening_enable_ipv6: false
+hardening_weekly_aide_check_minute: 0
+hardening_weekly_aide_check_hour: 3
+hardening_weekly_aide_check_day: 1
+hardening_disable_services:
+  - bluetooth.service
+  - cups.service
+hardening_additional_disable_services: []
+hardening_aide_init_timeout: 1800
+hardening_use_async_aide: true
+hardening_ipv6_disable_targets:
+  - net.ipv6.conf.all.disable_ipv6
+  - net.ipv6.conf.default.disable_ipv6
+  - net.ipv6.conf.lo.disable_ipv6
+hardening_sysctl_common:
+  - { name: 'net.ipv4.conf.all.accept_redirects', value: '0' }
+  - { name: 'net.ipv4.conf.all.send_redirects', value: '0' }
+  - { name: 'net.ipv4.conf.all.accept_source_route', value: '0' }
+  - { name: 'net.ipv4.icmp_echo_ignore_broadcasts', value: '1' }
+  - { name: 'net.ipv4.tcp_syncookies', value: '1' }
+  - { name: 'net.ipv4.conf.all.rp_filter', value: '1' }
+  - { name: 'net.ipv4.conf.default.rp_filter', value: '1' }
+  - { name: 'net.ipv4.conf.all.log_martians', value: '1' }
+  - { name: 'kernel.randomize_va_space', value: '2' }
+  - { name: 'kernel.panic', value: '10' }
+  - { name: 'kernel.yama.ptrace_scope', value: '1' }
+hardening_umask_targets:
+  - /etc/profile
+  - /etc/bash.bashrc
+  - /etc/zsh/zshrc
+hardening_aide_db_path: /var/lib/aide/aide.db.gz
+hardening_aide_new_db_path: /var/lib/aide/aide.db.new.gz
+hardening_firewalld_zone: public
+hardening_firewalld_services:
+  - cockpit
+hardening_firewalld_ports: []

--- a/roles/system_hardening/handlers/main.yml
+++ b/roles/system_hardening/handlers/main.yml
@@ -1,0 +1,9 @@
+---
+- name: Restart SSH service
+  ansible.builtin.service:
+    name: "{{ 'sshd' if ansible_os_family == 'RedHat' else 'ssh' }}"
+    state: restarted
+
+- name: Validate sudoers configuration
+  ansible.builtin.command: visudo -cf /etc/sudoers
+  changed_when: false

--- a/roles/system_hardening/tasks/common.yml
+++ b/roles/system_hardening/tasks/common.yml
@@ -1,0 +1,123 @@
+---
+- name: Resolve package set for distribution
+  ansible.builtin.set_fact:
+    hardening_package_target: "{{ hardening_packages_common.get(ansible_distribution, hardening_packages_common.get(ansible_os_family, [])) }}"
+
+- name: Ensure base hardening packages are installed
+  ansible.builtin.package:
+    name: "{{ hardening_package_target }}"
+    state: present
+  when: hardening_package_target | length > 0
+
+- name: Check for existing AIDE database
+  ansible.builtin.stat:
+    path: "{{ hardening_aide_db_path }}"
+  register: hardening_aide_db
+
+- name: Lock root password login
+  ansible.builtin.user:
+    name: root
+    password_lock: true
+
+- name: Apply kernel and network sysctl hardening
+  ansible.builtin.sysctl:
+    name: "{{ item.name }}"
+    value: "{{ item.value }}"
+    sysctl_set: true
+    reload: true
+  loop: "{{ hardening_sysctl_common }}"
+
+- name: Disable IPv6 when requested
+  ansible.builtin.sysctl:
+    name: "{{ item }}"
+    value: '1'
+    sysctl_set: true
+    reload: true
+  loop: "{{ hardening_ipv6_disable_targets }}"
+  when: not hardening_enable_ipv6
+
+- name: Configure SSH daemon hardening drop-in
+  ansible.builtin.template:
+    src: ssh_hardening.conf.j2
+    dest: /etc/ssh/sshd_config.d/hardening.conf
+    owner: root
+    group: root
+    mode: '0644'
+  notify: Restart SSH service
+
+- name: Ensure privileged separation directory exists
+  ansible.builtin.file:
+    path: "{{ item }}"
+    state: directory
+    owner: root
+    group: root
+    mode: '0755'
+  loop:
+    - /run/sshd
+    - /var/run/sshd
+    - /var/empty/sshd
+
+- name: Configure sudoers timeout policy
+  ansible.builtin.copy:
+    dest: /etc/sudoers.d/timeout
+    content: |-
+      Defaults timestamp_timeout=5
+    owner: root
+    group: root
+    mode: '0440'
+  notify: Validate sudoers configuration
+
+- name: Configure sudo cockpit exception
+  ansible.builtin.copy:
+    dest: /etc/sudoers.d/cockpit
+    content: |-
+      Defaults:cockpit !authenticate
+    owner: root
+    group: root
+    mode: '0440'
+  notify: Validate sudoers configuration
+
+- name: Require TTY for sudo invocations
+  ansible.builtin.copy:
+    dest: /etc/sudoers.d/requiretty
+    content: |-
+      Defaults requiretty
+    owner: root
+    group: root
+    mode: '0440'
+  notify: Validate sudoers configuration
+
+- name: Deploy SSH authorized keys when provided
+  ansible.builtin.authorized_key:
+    user: "{{ item.name }}"
+    key: "{{ item.key }}"
+    manage_dir: true
+  loop: "{{ hardening_authorized_users }}"
+  when: hardening_authorized_users | length > 0
+
+- name: Enforce secure umask defaults
+  ansible.builtin.lineinfile:
+    path: "{{ item }}"
+    line: 'umask 027'
+    insertafter: EOF
+    state: present
+  loop: "{{ hardening_umask_targets }}"
+  ignore_errors: true
+
+- name: Ensure weekly AIDE integrity check cron job exists
+  ansible.builtin.cron:
+    name: Weekly AIDE check
+    minute: "{{ hardening_weekly_aide_check_minute }}"
+    hour: "{{ hardening_weekly_aide_check_hour }}"
+    weekday: "{{ hardening_weekly_aide_check_day }}"
+    user: root
+    job: /usr/bin/aide --check
+    state: present
+
+- name: Disable unnecessary services
+  ansible.builtin.service:
+    name: "{{ item }}"
+    enabled: false
+    state: stopped
+  loop: "{{ (hardening_disable_services + hardening_additional_disable_services) | unique }}"
+  ignore_errors: true

--- a/roles/system_hardening/tasks/debian.yml
+++ b/roles/system_hardening/tasks/debian.yml
@@ -1,0 +1,99 @@
+---
+- name: Update apt cache
+  ansible.builtin.apt:
+    update_cache: true
+    cache_valid_time: 3600
+
+- name: Upgrade packages to latest available
+  ansible.builtin.apt:
+    upgrade: dist
+    autoremove: true
+
+- name: Ensure unattended upgrades configuration is present
+  ansible.builtin.copy:
+    dest: /etc/apt/apt.conf.d/20auto-upgrades
+    content: |-
+      APT::Periodic::Update-Package-Lists "1";
+      APT::Periodic::Unattended-Upgrade "1";
+      APT::Periodic::AutocleanInterval "7";
+    owner: root
+    group: root
+    mode: '0644'
+
+- name: Ensure ufw is installed
+  ansible.builtin.apt:
+    name: ufw
+    state: present
+
+- name: Configure ufw default policies
+  ansible.builtin.command: "{{ item }}"
+  args:
+    warn: false
+  loop:
+    - ufw default deny incoming
+    - ufw default allow outgoing
+  changed_when: false
+
+- name: Allow SSH and Cockpit in ufw
+  ansible.builtin.command: "ufw allow {{ item }}"
+  args:
+    warn: false
+  loop:
+    - "{{ hardening_ssh_port }}/tcp"
+    - 9090/tcp
+  changed_when: false
+
+- name: Enable ufw firewall
+  ansible.builtin.command: ufw --force enable
+  args:
+    warn: false
+  changed_when: false
+
+- name: Deploy fail2ban SSH jail configuration
+  ansible.builtin.template:
+    src: fail2ban_ssh.conf.j2
+    dest: /etc/fail2ban/jail.d/ssh.conf
+    owner: root
+    group: root
+    mode: '0644'
+
+- name: Enable security related services
+  ansible.builtin.service:
+    name: "{{ item }}"
+    state: started
+    enabled: true
+  loop:
+    - unattended-upgrades
+    - fail2ban
+    - auditd
+    - acct
+    - clamav-freshclam
+    - clamav-daemon
+
+- name: Update rkhunter databases
+  ansible.builtin.command: "{{ item }}"
+  changed_when: false
+  failed_when: false
+  loop:
+    - rkhunter --propupd
+    - rkhunter --update
+  when: ansible_facts.packages.get('rkhunter') is defined
+
+- name: Initialize AIDE database on Debian-based hosts
+  ansible.builtin.command: aideinit
+  register: aide_init_result
+  changed_when: aide_init_result.rc == 0
+  when:
+    - ansible_facts.packages.get('aide') is defined
+    - not hardening_aide_db.stat.exists
+
+- name: Record AIDE database initialization on Debian hosts
+  ansible.builtin.set_fact:
+    hardening_aide_db:
+      stat:
+        exists: true
+  when:
+    - ansible_facts.packages.get('aide') is defined
+    - aide_init_result is defined
+    - aide_init_result.rc == 0
+

--- a/roles/system_hardening/tasks/main.yml
+++ b/roles/system_hardening/tasks/main.yml
@@ -1,0 +1,15 @@
+---
+- name: Gather package facts
+  ansible.builtin.package_facts:
+    manager: auto
+
+- name: Include common hardening tasks
+  ansible.builtin.import_tasks: common.yml
+
+- name: Include Debian family hardening
+  ansible.builtin.include_tasks: debian.yml
+  when: ansible_os_family == 'Debian'
+
+- name: Include Red Hat family hardening
+  ansible.builtin.include_tasks: redhat.yml
+  when: ansible_os_family == 'RedHat'

--- a/roles/system_hardening/tasks/redhat.yml
+++ b/roles/system_hardening/tasks/redhat.yml
@@ -1,0 +1,196 @@
+---
+- name: Ensure latest packages are installed
+  ansible.builtin.dnf:
+    name: "*"
+    state: latest
+    update_cache: true
+
+- name: Query current firewalld default zone
+  ansible.builtin.command: firewall-cmd --get-default-zone
+  register: firewalld_current_zone
+  changed_when: false
+  failed_when: firewalld_current_zone.rc not in [0, 252]
+  when: ansible_facts.packages.get('firewalld') is defined
+
+- name: Configure firewalld default zone
+  ansible.builtin.command: "firewall-cmd --set-default-zone={{ hardening_firewalld_zone }}"
+  when:
+    - ansible_facts.packages.get('firewalld') is defined
+    - firewalld_current_zone.stdout is defined
+    - firewalld_current_zone.stdout.strip() != hardening_firewalld_zone
+
+- name: Ensure firewalld zone target is drop
+  ansible.posix.firewalld:
+    zone: "{{ hardening_firewalld_zone }}"
+    target: DROP
+    permanent: true
+    immediate: true
+  when: ansible_facts.packages.get('firewalld') is defined
+
+- name: Allow cockpit service via firewalld
+  ansible.posix.firewalld:
+    zone: "{{ hardening_firewalld_zone }}"
+    service: "{{ item }}"
+    permanent: true
+    state: enabled
+    immediate: true
+  loop: "{{ hardening_firewalld_services }}"
+  when: ansible_facts.packages.get('firewalld') is defined
+
+- name: Allow SSH port via firewalld
+  ansible.posix.firewalld:
+    zone: "{{ hardening_firewalld_zone }}"
+    port: "{{ item }}"
+    permanent: true
+    state: enabled
+    immediate: true
+  loop: "{{ hardening_firewalld_ports_map.get('default') }}"
+  when: ansible_facts.packages.get('firewalld') is defined
+
+- name: Reload firewalld configuration
+  ansible.posix.firewalld:
+    state: reloaded
+  when: ansible_facts.packages.get('firewalld') is defined
+
+- name: Ensure SELinux configuration file enforces mode
+  ansible.builtin.replace:
+    path: /etc/selinux/config
+    regexp: '^SELINUX=.*'
+    replace: 'SELINUX=enforcing'
+  notify: Restart SSH service
+  when: ansible_facts.packages.get('selinux-policy-targeted') is defined
+
+- name: Set SELinux enforcing at runtime
+  ansible.builtin.command: setenforce 1
+  changed_when: false
+  failed_when: false
+  when:
+    - ansible_selinux is defined
+    - ansible_selinux.status == 'enabled'
+    - ansible_selinux.mode != 'enforcing'
+
+- name: Allow SSH custom port in SELinux
+  ansible.posix.seport:
+    ports: "{{ hardening_ssh_port }}"
+    proto: tcp
+    setype: ssh_port_t
+    state: present
+  when:
+    - hardening_ssh_port | int != 22
+    - ansible_selinux is defined
+    - ansible_selinux.status == 'enabled'
+
+- name: Deploy fail2ban SSH jail configuration
+  ansible.builtin.template:
+    src: fail2ban_ssh.conf.j2
+    dest: /etc/fail2ban/jail.d/ssh.conf
+    owner: root
+    group: root
+    mode: '0644'
+
+- name: Configure dnf-automatic for security updates
+  ansible.builtin.ini_file:
+    path: /etc/dnf/automatic.conf
+    section: commands
+    option: apply_updates
+    value: 'yes'
+  when: ansible_facts.packages.get('dnf-automatic') is defined
+
+- name: Configure dnf-automatic security only
+  ansible.builtin.ini_file:
+    path: /etc/dnf/automatic.conf
+    section: commands
+    option: upgrade_type
+    value: security
+  when: ansible_facts.packages.get('dnf-automatic') is defined
+
+- name: Ensure dnf-automatic timer enabled
+  ansible.builtin.systemd:
+    name: dnf-automatic.timer
+    state: started
+    enabled: true
+  when: ansible_facts.packages.get('dnf-automatic') is defined
+
+- name: Prepare ClamAV directories
+  ansible.builtin.file:
+    path: "{{ item }}"
+    state: directory
+    owner: clamav
+    group: clamav
+    mode: '0755'
+  loop:
+    - /var/lib/clamav
+    - /run/clamd.scan
+    - /var/log/clamd.scan
+  ignore_errors: true
+  when: ansible_facts.packages.get('clamav') is defined
+
+- name: Update ClamAV signatures
+  ansible.builtin.command: timeout 300 freshclam
+  changed_when: false
+  failed_when: false
+  when: ansible_facts.packages.get('clamav') is defined
+
+- name: Ensure security services are enabled
+  ansible.builtin.systemd:
+    name: "{{ item }}"
+    state: started
+    enabled: true
+  loop:
+    - fail2ban
+    - auditd
+    - clamd@scan
+  ignore_errors: true
+
+- name: Run initial chkrootkit scan
+  ansible.builtin.command: chkrootkit
+  args:
+    creates: /var/log/chkrootkit-initial.log
+  register: chkrootkit_run
+  failed_when: false
+  changed_when: chkrootkit_run.rc == 0
+  when: ansible_facts.packages.get('chkrootkit') is defined
+
+- name: Capture chkrootkit initial log
+  ansible.builtin.copy:
+    dest: /var/log/chkrootkit-initial.log
+    content: "{{ chkrootkit_run.stdout }}\n{{ chkrootkit_run.stderr }}"
+  when: chkrootkit_run is defined and chkrootkit_run.stdout is defined
+
+- name: Schedule weekly chkrootkit scan
+  ansible.builtin.cron:
+    name: Weekly chkrootkit scan
+    minute: 0
+    hour: 2
+    weekday: 0
+    job: "/usr/sbin/chkrootkit > /var/log/chkrootkit-weekly.log 2>&1"
+    user: root
+  when: ansible_facts.packages.get('chkrootkit') is defined
+
+- name: Initialize AIDE database on Red Hat hosts
+  ansible.builtin.command: aide --init
+  args:
+    creates: "{{ hardening_aide_new_db_path }}"
+  register: aide_init_redhat
+  changed_when: aide_init_redhat.rc == 0
+  when:
+    - ansible_facts.packages.get('aide') is defined
+    - not hardening_aide_db.stat.exists
+
+- name: Promote initialized AIDE database
+  ansible.builtin.command: "mv {{ hardening_aide_new_db_path }} {{ hardening_aide_db_path }}"
+  when:
+    - ansible_facts.packages.get('aide') is defined
+    - aide_init_redhat is defined
+    - aide_init_redhat.rc == 0
+    - aide_init_redhat is changed
+
+- name: Record AIDE database initialization on Red Hat hosts
+  ansible.builtin.set_fact:
+    hardening_aide_db:
+      stat:
+        exists: true
+  when:
+    - ansible_facts.packages.get('aide') is defined
+    - aide_init_redhat is defined
+    - aide_init_redhat.rc == 0

--- a/roles/system_hardening/templates/fail2ban_ssh.conf.j2
+++ b/roles/system_hardening/templates/fail2ban_ssh.conf.j2
@@ -1,0 +1,9 @@
+[sshd]
+enabled = true
+port = {{ hardening_ssh_port }}
+filter = sshd
+logpath = {{ hardening_fail2ban_log_path_map.get(ansible_distribution, hardening_fail2ban_log_path_map.get(ansible_os_family, '/var/log/auth.log')) }}
+backend = {{ 'systemd' if ansible_os_family == 'RedHat' else 'auto' }}
+maxretry = {{ hardening_fail2ban_maxretry }}
+bantime = {{ hardening_fail2ban_bantime }}
+findtime = {{ hardening_fail2ban_findtime }}

--- a/roles/system_hardening/templates/ssh_hardening.conf.j2
+++ b/roles/system_hardening/templates/ssh_hardening.conf.j2
@@ -1,0 +1,22 @@
+Port {{ hardening_ssh_port }}
+PermitRootLogin no
+PasswordAuthentication no
+PubkeyAuthentication yes
+MaxAuthTries 3
+ClientAliveInterval 300
+ClientAliveCountMax 2
+X11Forwarding no
+AllowTcpForwarding no
+IgnoreRhosts yes
+HostbasedAuthentication no
+PermitEmptyPasswords no
+ChallengeResponseAuthentication no
+KbdInteractiveAuthentication no
+KerberosAuthentication no
+GSSAPIAuthentication no
+UsePAM yes
+PrintMotd no
+TCPKeepAlive yes
+Compression delayed
+MaxStartups 2
+LoginGraceTime 30

--- a/roles/system_hardening/vars/main.yml
+++ b/roles/system_hardening/vars/main.yml
@@ -1,0 +1,66 @@
+---
+hardening_packages_common:
+  Debian:
+    - python3
+    - openssh-server
+    - cockpit
+    - cockpit-networkmanager
+    - cockpit-packagekit
+    - cockpit-storaged
+    - cockpit-sosreport
+    - unattended-upgrades
+    - fail2ban
+    - auditd
+    - acct
+    - clamav
+    - clamav-daemon
+    - rkhunter
+    - aide
+    - ufw
+  Ubuntu:
+    - python3
+    - openssh-server
+    - cockpit
+    - cockpit-networkmanager
+    - cockpit-packagekit
+    - cockpit-storaged
+    - cockpit-pcp
+    - cockpit-sosreport
+    - cockpit-tuned
+    - unattended-upgrades
+    - fail2ban
+    - auditd
+    - acct
+    - clamav
+    - clamav-daemon
+    - rkhunter
+    - aide
+    - ufw
+  AlmaLinux:
+    - python3
+    - openssh-server
+    - cockpit
+    - cockpit-networkmanager
+    - cockpit-packagekit
+    - cockpit-storaged
+    - cockpit-sosreport
+    - selinux-policy-targeted
+    - policycoreutils-python-utils
+    - dnf-automatic
+    - epel-release
+    - fail2ban
+    - python3-fail2ban
+    - audit
+    - clamav
+    - clamav-update
+    - clamd
+    - chkrootkit
+    - aide
+    - firewalld
+hardening_firewalld_ports_map:
+  default:
+    - "{{ hardening_ssh_port }}/tcp"
+hardening_fail2ban_log_path_map:
+  Debian: /var/log/auth.log
+  Ubuntu: /var/log/auth.log
+  AlmaLinux: /var/log/secure


### PR DESCRIPTION
## Summary
- add a `system_hardening` role that configures SSH, firewalling, security tooling, and AIDE on Ubuntu, Debian, and AlmaLinux hosts
- add dedicated `podman_host`, `docker_host`, and `kubernetes_host` roles with distro-aware package management and runtime configuration
- provide templates and defaults for container security policies, sudo policies, and supporting configuration files to keep the roles idempotent

## Testing
- not run (infrastructure-only change)


------
https://chatgpt.com/codex/tasks/task_e_68f3cb81ff8c832eaa44b0f2e0a8199a