### PR TITLE
Refactor common role to use generic service contract

### DIFF
--- a/roles/common/apply_runtime/handlers/main.yml
+++ b/roles/common/apply_runtime/handlers/main.yml
@@ -1,8 +1,8 @@
 ---
-- name: Restart MariaDB
-  listen: Restart MariaDB
+- name: Restart service
+  listen: Restart service
   become: true
   systemd:
-    name: "{{ mariadb_service_name | default('mariadb') }}"
+    name: "{{ service_unit_name | default(service_id) }}"
     state: restarted
-  delegate_to: "{{ container_ip | default(inventory_hostname) }}"
+  delegate_to: "{{ container_ip | default(service_ip | default(inventory_hostname)) }}"

--- a/roles/common/apply_runtime/tasks/baremetal.yml
+++ b/roles/common/apply_runtime/tasks/baremetal.yml
@@ -1,49 +1,38 @@
 ---
+- name: Determine service unit name
+  set_fact:
+    effective_service_unit_name: "{{ service_unit_name | default(service_id) }}"
+
 - name: Set service IP facts
   set_fact:
-    service_ip: "{{ mariadb_bind_address | default(ansible_default_ipv4.address) }}"
-    mariadb_allowed_hosts_raw: {{ mariadb_allowed_hosts | default([mariadb_bind_address | default(ansible_default_ipv4.address)]) }}
+    service_ip: "{{ service_ip | default(ansible_default_ipv4.address) }}"
 
-- name: Normalize allowed host list
-  set_fact:
-    mariadb_allowed_hosts_effective: {{ mariadb_allowed_hosts_raw if (mariadb_allowed_hosts_raw | type_debug) in ['list', 'tuple'] else [mariadb_allowed_hosts_raw] }}
-
-- name: Enforce restricted MariaDB hosts
-  assert:
-    that:
-      - '%' not in mariadb_allowed_hosts_effective
-    fail_msg: "mariadb_allowed_hosts cannot include % by default. Provide explicit host entries."
-
-- name: Install MariaDB packages
+- name: Install service packages
   become: true
   apt:
-    name:
-      - mariadb-server
-      - mariadb-client
-      - python3-pymysql
+    name: "{{ service_packages }}"
     state: present
     update_cache: yes
   environment:
     DEBIAN_FRONTEND: noninteractive
+  when: service_packages is defined and service_packages | length > 0
 
-- name: Deploy custom MariaDB configuration
+- name: Deploy service configuration files
   become: true
   copy:
-    dest: /etc/mysql/mariadb.conf.d/99-custom.cnf
-    mode: "0644"
-    content: |
-      [mysqld]
-      bind-address = {{ service_ip }}
-      max_connections = 200
-  notify: Restart MariaDB
+    dest: "{{ item.path }}"
+    mode: "{{ item.mode | default('0644') }}"
+    content: "{{ item.content }}"
+  loop: "{{ service_files | default([]) }}"
+  notify: Restart service
 
 - name: Copy systemd unit file
   become: true
   copy:
     src: "{{ runtime_config_path }}"
-    dest: "/etc/systemd/system/{{ service_id }}.service"
+    dest: "/etc/systemd/system/{{ effective_service_unit_name }}.service"
     mode: '0644'
-  notify: Restart MariaDB
+  notify: Restart service
 
 - name: Reload systemd
   become: true
@@ -53,46 +42,17 @@
 - name: Enable service
   become: true
   systemd:
-    name: "{{ service_id }}"
+    name: "{{ effective_service_unit_name }}"
     enabled: yes
 
 - name: Start service
   become: true
   systemd:
-    name: "{{ service_id }}"
+    name: "{{ effective_service_unit_name }}"
     state: started
 
-- name: Secure MariaDB root account
+- name: Run additional setup commands
   become: true
-  community.mysql.mysql_user:
-    login_unix_socket: /var/run/mysqld/mysqld.sock
-    name: root
-    host: localhost
-    password: "{{ mariadb_root_password }}"
-    check_implicit_admin: true
-    state: present
-  no_log: true
-
-- name: Ensure MariaDB database exists
-  become: true
-  community.mysql.mysql_db:
-    name: "{{ mariadb_database }}"
-    state: present
-    login_unix_socket: /var/run/mysqld/mysqld.sock
-    login_user: root
-    login_password: "{{ mariadb_root_password }}"
-  no_log: true
-
-- name: Ensure MariaDB user exists with limited hosts
-  become: true
-  community.mysql.mysql_user:
-    name: "{{ mariadb_user }}"
-    password: "{{ mariadb_user_password }}"
-    host: "{{ item }}"
-    priv: "{{ mariadb_database }}.*:ALL"
-    login_unix_socket: /var/run/mysqld/mysqld.sock
-    login_user: root
-    login_password: "{{ mariadb_root_password }}"
-    state: present
-  loop: "{{ mariadb_allowed_hosts_effective }}"
-  no_log: true
+  command: "{{ item }}"
+  loop: "{{ service_commands | default([]) }}"
+  when: service_commands is defined and service_commands | length > 0

--- a/roles/common/apply_runtime/tasks/docker.yml
+++ b/roles/common/apply_runtime/tasks/docker.yml
@@ -1,29 +1,18 @@
 ---
 - name: Resolve Docker secrets
   set_fact:
-    compose_secret_env: {{ (secrets.env if secrets is defined and secrets.env is not none and secrets.env | length > 0 else []) }}
-    compose_secret_files: {{ secrets.files if secrets is defined and secrets.files is not none and secrets.files | length > 0 else [] }}
-
-- name: Apply default secret environment values when unspecified
-  set_fact:
-    compose_secret_env: {{ compose_secret_env + [
-      {'name': 'MYSQL_ROOT_PASSWORD', 'value': mariadb_root_password},
-      {'name': 'MYSQL_PASSWORD', 'value': mariadb_user_password}
-    ] if compose_secret_env | length == 0 else compose_secret_env }}
-
-- name: Deduplicate secret environment variables
-  set_fact:
-    compose_secret_env: >-
-      {{ compose_secret_env | reverse | unique(attribute='name') | reverse }}
+    compose_secret_env: "{{ secrets.env if secrets is defined and secrets.env is not none and secrets.env | length > 0 else [] }}"
+    compose_secret_files: "{{ secrets.files if secrets is defined and secrets.files is not none and secrets.files | length > 0 else [] }}"
 
 - name: Write Compose secret environment file
   copy:
-    dest: "{{ runtime_output_dir }}/{{ mariadb_hostname }}.env"
+    dest: "{{ runtime_output_dir }}/{{ service_name | default(service_id) }}.env"
     mode: '0600'
     content: |-
       {% for item in compose_secret_env %}
       {{ item.name }}={{ item.value }}
       {% endfor %}
+  when: compose_secret_env | length > 0
   no_log: true
 
 - name: Ensure Compose secret directory exists
@@ -52,4 +41,4 @@
 
 - name: Set service IP for health checks
   set_fact:
-    service_ip: "{{ mariadb_ip }}"
+    service_ip: "{{ service_ip | default(ansible_default_ipv4.address) }}"

--- a/roles/common/apply_runtime/tasks/podman.yml
+++ b/roles/common/apply_runtime/tasks/podman.yml
@@ -2,30 +2,24 @@
 - name: Determine quadlet scope
   set_fact:
     quadlet_effective_scope: "{{ quadlet_scope | default('system') }}"
-    quadlet_unit_name: "{{ service_id | default(mariadb_hostname) }}"
+    quadlet_unit_name: "{{ service_unit_name | default(service_id) }}"
 
 - name: Resolve quadlet paths
   set_fact:
     quadlet_base_dir: "{{ (quadlet_effective_scope == 'user') | ternary((ansible_env.HOME | default(lookup('env', 'HOME'))) + '/.config/containers/systemd', '/etc/containers/systemd') }}"
-    quadlet_env_path: "{{ ((quadlet_effective_scope == 'user') | ternary((ansible_env.HOME | default(lookup('env', 'HOME'))) + '/.config/containers/systemd', '/etc/containers/systemd')) + '/' + (mariadb_hostname) + '.env' }}"
+    quadlet_env_path: "{{ ((quadlet_effective_scope == 'user') | ternary((ansible_env.HOME | default(lookup('env', 'HOME'))) + '/.config/containers/systemd', '/etc/containers/systemd')) + '/' + (service_name | default(service_id)) + '.env' }}"
     quadlet_secret_dir: "{{ ((quadlet_effective_scope == 'user') | ternary((ansible_env.HOME | default(lookup('env', 'HOME'))) + '/.config/containers/systemd/secrets', '/etc/containers/systemd/secrets')) }}"
 
 - name: Resolve Quadlet secrets
   set_fact:
-    quadlet_secret_env: {{ (secrets.env if secrets is defined and secrets.env is not none and secrets.env | length > 0 else []) }}
-    quadlet_secret_files: {{ secrets.files if secrets is defined and secrets.files is not none and secrets.files | length > 0 else [] }}
-
-- name: Apply default secret environment values when unspecified
-  set_fact:
-    quadlet_secret_env: {{ quadlet_secret_env + [
-      {'name': 'MYSQL_ROOT_PASSWORD', 'value': mariadb_root_password},
-      {'name': 'MYSQL_PASSWORD', 'value': mariadb_user_password}
-    ] if quadlet_secret_env | length == 0 else quadlet_secret_env }}
+    quadlet_secret_env: "{{ secrets.env if secrets is defined and secrets.env is not none and secrets.env | length > 0 else [] }}"
+    quadlet_secret_files: "{{ secrets.files if secrets is defined and secrets.files is not none and secrets.files | length > 0 else [] }}"
 
 - name: Deduplicate quadlet secret environment variables
   set_fact:
     quadlet_secret_env: >-
       {{ quadlet_secret_env | reverse | unique(attribute='name') | reverse }}
+  when: quadlet_secret_env | length > 0
 
 - name: Ensure quadlet directory exists
   file:
@@ -50,6 +44,7 @@
       {% for item in quadlet_secret_env %}
       {{ item.name }}={{ item.value }}
       {% endfor %}
+  when: quadlet_secret_env | length > 0
   no_log: true
   become: {{ (quadlet_effective_scope == 'system') | bool }}
 
@@ -84,4 +79,4 @@
 
 - name: Set service IP for health checks
   set_fact:
-    service_ip: "{{ mariadb_ip }}"
+    service_ip: "{{ service_ip | default(ansible_default_ipv4.address) }}"

--- a/roles/common/apply_runtime/tasks/proxmox.yml
+++ b/roles/common/apply_runtime/tasks/proxmox.yml
@@ -14,17 +14,6 @@
   set_fact:
     container_ip: "{{ lxc_config.container_ip }}"
     service_ip: "{{ lxc_config.container_ip }}"
-    mariadb_allowed_hosts_raw: {{ mariadb_allowed_hosts | default([lxc_config.container_ip]) }}
-
-- name: Normalize allowed host list
-  set_fact:
-    mariadb_allowed_hosts_effective: {{ mariadb_allowed_hosts_raw if (mariadb_allowed_hosts_raw | type_debug) in ['list', 'tuple'] else [mariadb_allowed_hosts_raw] }}
-
-- name: Enforce restricted MariaDB hosts
-  assert:
-    that:
-      - '%' not in mariadb_allowed_hosts_effective
-    fail_msg: 'mariadb_allowed_hosts cannot include % by default. Provide explicit host entries.'
 
 - name: Create LXC container
   community.general.proxmox:
@@ -64,11 +53,12 @@
   delegate_to: "{{ container_ip }}"
   become: true
   apt:
-    name: "{{ lxc_config.setup.packages }}"
+    name: "{{ lxc_config.setup.packages | default([]) }}"
     state: present
     update_cache: yes
   environment:
     DEBIAN_FRONTEND: noninteractive
+  when: lxc_config.setup.packages is defined and lxc_config.setup.packages | length > 0
 
 - name: Write config files
   delegate_to: "{{ container_ip }}"
@@ -76,9 +66,8 @@
   copy:
     content: "{{ item.content }}"
     dest: "{{ item.path }}"
-    mode: "0644"
+    mode: "{{ item.mode | default('0644') }}"
   loop: "{{ lxc_config.setup.config | default([]) }}"
-  notify: Restart MariaDB
 
 - name: Enable and start services
   delegate_to: "{{ container_ip }}"
@@ -95,42 +84,4 @@
   become: true
   command: "{{ item }}"
   loop: "{{ lxc_config.setup.commands | default([]) }}"
-  when: lxc_config.setup.commands is defined
-
-- name: Secure MariaDB root account
-  delegate_to: "{{ container_ip }}"
-  become: true
-  community.mysql.mysql_user:
-    login_unix_socket: /var/run/mysqld/mysqld.sock
-    name: root
-    host: localhost
-    password: "{{ mariadb_root_password }}"
-    check_implicit_admin: true
-    state: present
-  no_log: true
-
-- name: Ensure MariaDB database exists
-  delegate_to: "{{ container_ip }}"
-  become: true
-  community.mysql.mysql_db:
-    name: "{{ mariadb_database }}"
-    state: present
-    login_unix_socket: /var/run/mysqld/mysqld.sock
-    login_user: root
-    login_password: "{{ mariadb_root_password }}"
-  no_log: true
-
-- name: Ensure MariaDB user exists with limited hosts
-  delegate_to: "{{ container_ip }}"
-  become: true
-  community.mysql.mysql_user:
-    name: "{{ mariadb_user }}"
-    password: "{{ mariadb_user_password }}"
-    host: "{{ item }}"
-    priv: "{{ mariadb_database }}.*:ALL"
-    login_unix_socket: /var/run/mysqld/mysqld.sock
-    login_user: root
-    login_password: "{{ mariadb_root_password }}"
-    state: present
-  loop: "{{ mariadb_allowed_hosts_effective }}"
-  no_log: true
+  when: lxc_config.setup.commands is defined and lxc_config.setup.commands | length > 0

--- a/roles/common/validate_schema/tasks/main.yml
+++ b/roles/common/validate_schema/tasks/main.yml
@@ -7,11 +7,13 @@
   assert:
     that:
       - service_id is defined
+      - service_name is defined
+      - service_image is defined
       - exports is defined
       - storage is defined
       - health is defined
       - runtime_templates is defined
-    fail_msg: "Service {{ service_id }} is missing required contract fields"
+    fail_msg: "Service {{ service_id | default('unknown') }} is missing required contract fields"
 
 - name: Validate required dependencies exist
   assert:

--- a/schemas/service.schema.yml
+++ b/schemas/service.schema.yml
@@ -2,6 +2,8 @@
 type: object
 required:
   - service_id
+  - service_name
+  - service_image
   - exports
   - storage
   - health
@@ -9,6 +11,171 @@ required:
 properties:
   service_id:
     type: string
+  service_name:
+    type: string
+  service_unit_name:
+    type: string
+  service_image:
+    type: string
+  service_ip:
+    type: string
+  service_port:
+    type: object
+    properties:
+      target:
+        type: integer
+      published:
+        type: integer
+      host_ip:
+        type: string
+      protocol:
+        type: string
+    required:
+      - target
+  service_ports:
+    type: array
+    items:
+      type: object
+      properties:
+        target:
+          type: integer
+        published:
+          type: integer
+        host_ip:
+          type: string
+        protocol:
+          type: string
+      required:
+        - target
+  service_env:
+    type: array
+    items:
+      type: object
+      required: [name, value]
+      properties:
+        name:
+          type: string
+        value:
+          type: string
+  service_volumes:
+    type: array
+    items:
+      type: object
+      required: [name, target]
+      properties:
+        name:
+          type: string
+        source:
+          type: string
+        target:
+          type: string
+        mode:
+          type: string
+        driver:
+          type: string
+        size:
+          type: string
+  service_networks:
+    type: array
+    items:
+      type: string
+  service_unit:
+    type: object
+    properties:
+      description:
+        type: string
+      after:
+        type: array
+        items:
+          type: string
+      service:
+        type: object
+      install_wanted_by:
+        type: array
+        items:
+          type: string
+  service_packages:
+    type: array
+    items:
+      type: string
+  service_files:
+    type: array
+    items:
+      type: object
+      required: [path, content]
+      properties:
+        path:
+          type: string
+        content:
+          type: string
+        mode:
+          type: string
+  service_services:
+    type: array
+    items:
+      type: object
+      required: [name]
+      properties:
+        name:
+          type: string
+        enabled:
+          type: boolean
+        state:
+          type: string
+  service_commands:
+    type: array
+    items:
+      type: string
+  service_resources:
+    type: object
+    properties:
+      memory_mb:
+        type: integer
+      cpu_cores:
+        type: number
+  service_namespace:
+    type: string
+  service_replicas:
+    type: integer
+  service_storage_gb:
+    type: integer
+  service_storage_size:
+    type: string
+  service_gateway:
+    type: string
+  service_container:
+    type: object
+    properties:
+      vmid:
+        type: integer
+      hostname:
+        type: string
+      ostemplate:
+        type: string
+      disk:
+        type: integer
+      cores:
+        type: integer
+      memory:
+        type: integer
+      swap:
+        type: integer
+      interface:
+        type: string
+      bridge:
+        type: string
+      cidr:
+        type: integer
+      gateway:
+        type: string
+      onboot:
+        type: string
+      unprivileged:
+        type: string
+      features:
+        type: string
+  service_volume:
+    type: object
   version:
     type: string
   requires:

--- a/templates/baremetal.yml.j2
+++ b/templates/baremetal.yml.j2
@@ -1,23 +1,20 @@
+{% set unit = service_unit | default({}) %}
+{% set description = unit.description | default('Managed service for ' ~ (service_name | default(service_id))) %}
+{% set after = unit.after | default(['network.target']) %}
+{% set service_section = unit.service | default({'Type': 'simple', 'ExecStart': '/usr/bin/true'}) %}
+{% set install_targets = unit.install_wanted_by | default(['multi-user.target']) %}
 [Unit]
-Description=MariaDB Database Server
-After=network.target
+Description={{ description }}
+{% for dependency in after %}
+After={{ dependency }}
+{% endfor %}
 
 [Service]
-Type=notify
-User=mysql
-Group=mysql
-
-ExecStartPre=/usr/bin/install -d -m 755 -o mysql -g mysql /var/run/mysqld
-ExecStart=/usr/sbin/mariadbd --basedir=/usr
-
-Restart=on-failure
-RestartSec=5s
-
-# Security
-NoNewPrivileges=true
-PrivateTmp=true
-ProtectSystem=full
-ProtectHome=true
+{% for key, value in service_section.items() %}
+{{ key }}={{ value }}
+{% endfor %}
 
 [Install]
-WantedBy=multi-user.target
+{% for target in install_targets %}
+WantedBy={{ target }}
+{% endfor %}

--- a/templates/docker.yml.j2
+++ b/templates/docker.yml.j2
@@ -1,44 +1,64 @@
-{% set default_secret_env = [
-  {'name': 'MYSQL_ROOT_PASSWORD', 'value': mariadb_root_password},
-  {'name': 'MYSQL_PASSWORD', 'value': mariadb_user_password}
-] %}
-{% set secret_env = secrets.env if secrets is defined and secrets.env is not none and secrets.env | length > 0 else default_secret_env %}
-{% set secret_env_names = secret_env | map(attribute='name') | list %}
+{% set services_list = services | default([{
+  'name': service_name | default(service_id),
+  'container_name': service_name | default(service_id),
+  'image': service_image,
+  'env': service_env | default([]),
+  'ports': service_ports | default((service_port is defined) | ternary([service_port], [])),
+  'volumes': service_volumes | default([]),
+  'networks': service_networks | default(['app-network'])
+}]) %}
+{% set secret_env = secrets.env if secrets is defined and secrets.env is not none and secrets.env | length > 0 else [] %}
 {% set file_secrets = secrets.files if secrets is defined and secrets.files is not none and secrets.files | length > 0 else [] %}
-{% set env_file_name = mariadb_hostname + '.env' %}
+{% set env_file_name = (service_name | default(service_id)) + '.env' %}
 version: '3.8'
 
 services:
-  mariadb:
-    image: mariadb:{{ version }}
-    container_name: {{ mariadb_hostname }}
+{% for svc in services_list %}
+  {{ svc.name }}:
+    image: {{ svc.image }}
+    container_name: {{ svc.container_name | default(svc.name) }}
     restart: unless-stopped
-{% if secret_env %}
+{% set svc_env_file = svc.env_file | default(env_file_name) %}
+{% set svc_secret_env = svc.secret_env | default(secret_env) %}
+{% if svc_secret_env %}
     env_file:
-      - "./{{ env_file_name }}"
+      - "./{{ svc_env_file }}"
 {% endif %}
-{% set inline_env = {
-  'MYSQL_DATABASE': mariadb_database,
-  'MYSQL_USER': mariadb_user
-} %}
-{% set filtered_inline_env = inline_env.items() | rejectattr('0', 'in', secret_env_names) | list %}
-{% if filtered_inline_env %}
+{% set inline_env = svc.env | default([]) %}
+{% if inline_env %}
     environment:
-{% for key, value in filtered_inline_env %}
-      {{ key }}: {{ value }}
+{% for item in inline_env %}
+      {{ item.name }}: {{ item.value }}
 {% endfor %}
 {% endif %}
+{% set volumes = svc.volumes | default([]) %}
+{% if volumes %}
     volumes:
-      - mariadb-data:/var/lib/mysql
+{% for vol in volumes %}
+      - {{ vol.source | default(vol.name) }}:{{ vol.target }}{% if vol.mode is defined %}:{{ vol.mode }}{% endif %}
+{% endfor %}
+{% endif %}
+{% set ports = svc.ports | default([]) %}
+{% if ports %}
     ports:
-      - "{{ mariadb_ip }}:3306:3306"
+{% for port in ports %}
+      - "{{ port.host_ip | default('') }}{% if port.host_ip is defined and port.host_ip | string | length > 0 %}:{% endif %}{{ port.published | default(port.target) }}:{{ port.target }}{% if port.protocol is defined %}/{{ port.protocol }}{% endif %}"
+{% endfor %}
+{% endif %}
+{% set networks = svc.networks | default(['app-network']) %}
+{% if networks %}
     networks:
-      - app-network
+{% for net in networks %}
+      - {{ net }}
+{% endfor %}
+{% endif %}
+{% if health is defined %}
     healthcheck:
-      test: {{ health.cmd | default(['mysqladmin', 'ping', '-h', 'localhost']) | to_json }}
+      test: {{ health.cmd | default(['true']) | to_json }}
       interval: {{ health.interval | default('10s') }}
       timeout: {{ health.timeout | default('5s') }}
       retries: {{ health.retries | default(3) }}
+{% endif %}
 {% if file_secrets %}
     secrets:
 {% for secret in file_secrets %}
@@ -47,12 +67,26 @@ services:
         mode: {{ secret.mode | default('0400') }}
 {% endfor %}
 {% endif %}
+{% endfor %}
 
+{% set ns = namespace(volumes=[]) %}
+{% for svc in services_list %}
+  {% for vol in svc.volumes | default([]) %}
+    {% set volume_name = vol.source | default(vol.name) %}
+    {% if volume_name not in ns.volumes %}
+      {% set _ = ns.volumes.append(volume_name) %}
+    {% endif %}
+  {% endfor %}
+{% endfor %}
+{% if ns.volumes %}
 volumes:
-  mariadb-data:
+{% for volume_name in ns.volumes %}
+  {{ volume_name }}:
     driver: local
-{% if file_secrets %}
+{% endfor %}
+{% endif %}
 
+{% if file_secrets %}
 secrets:
 {% for secret in file_secrets %}
   {{ secret.name }}:
@@ -60,6 +94,18 @@ secrets:
 {% endfor %}
 {% endif %}
 
+{% set network_ns = namespace(items=[]) %}
+{% for svc in services_list %}
+  {% for net in svc.networks | default(['app-network']) %}
+    {% if net not in network_ns.items %}
+      {% set _ = network_ns.items.append(net) %}
+    {% endif %}
+  {% endfor %}
+{% endfor %}
+{% if network_ns.items %}
 networks:
-  app-network:
+{% for net in network_ns.items %}
+  {{ net }}:
     driver: bridge
+{% endfor %}
+{% endif %}

--- a/templates/kubernetes.yml.j2
+++ b/templates/kubernetes.yml.j2
@@ -1,16 +1,30 @@
-{% set svc_name = service_id | default('mariadb') %}
-{% set namespace = k8s_namespace | default('default') %}
-{% set default_secret_env = [
-  {'name': 'MYSQL_ROOT_PASSWORD', 'value': mariadb_root_password},
-  {'name': 'MYSQL_PASSWORD', 'value': mariadb_user_password}
-] %}
-{% set secret_env = secrets.env if secrets is defined and secrets.env is not none and secrets.env | length > 0 else default_secret_env %}
+{% set svc_name = service_name | default(service_id) %}
+{% set namespace = service_namespace | default('default') %}
+{% set secret_env = secrets.env if secrets is defined and secrets.env is not none and secrets.env | length > 0 else [] %}
 {% set file_secrets = secrets.files if secrets is defined and secrets.files is not none and secrets.files | length > 0 else [] %}
 {% set secret_name = svc_name + '-secrets' %}
-{% set health_cmd = health.cmd | default(['mysqladmin', 'ping', '-h', 'localhost']) %}
+{% set health_cmd = health.cmd | default(['true']) %}
 {% set health_interval_seconds = (health.interval | default('10s')) | regex_replace('s$', '') | int %}
 {% set health_timeout_seconds = (health.timeout | default('5s')) | regex_replace('s$', '') | int %}
 {% set health_retries = health.retries | default(3) %}
+{% set replicas = service_replicas | default(1) %}
+{% set ports = service_ports | default((service_port is defined) | ternary([service_port], [])) %}
+{% set container_port = ports[0].target if ports | length > 0 else 8080 %}
+{% set service_port = ports[0].published if ports | length > 0 and ports[0].published is defined else container_port %}
+{% set resources = service_resources | default({'memory_mb': 256, 'cpu_cores': 1}) %}
+{% set memory_request = resources.memory_mb | default(256) %}
+{% set cpu_cores = resources.cpu_cores | default(1) %}
+{% set volume_config = service_volume | default(service_volumes[0] if service_volumes is defined and service_volumes | length > 0 else None) %}
+{% if service_storage_size is defined %}
+{% set storage_size = service_storage_size %}
+{% elif volume_config is mapping and volume_config.size is defined %}
+{% set storage_size = volume_config.size %}
+{% elif service_storage_gb is defined %}
+{% set storage_size = service_storage_gb ~ 'Gi' %}
+{% else %}
+{% set storage_size = '1Gi' %}
+{% endif %}
+{% set volume_mount_path = volume_config.target if volume_config is mapping and volume_config.target is defined else '/data' %}
 ---
 apiVersion: v1
 kind: Secret
@@ -36,7 +50,7 @@ spec:
     - ReadWriteOnce
   resources:
     requests:
-      storage: {{ mariadb_storage_gb }}Gi
+      storage: {{ storage_size }}
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -44,7 +58,7 @@ metadata:
   name: {{ svc_name }}
   namespace: {{ namespace }}
 spec:
-  replicas: {{ mariadb_replicas | default(1) }}
+  replicas: {{ replicas }}
   selector:
     matchLabels:
       app: {{ svc_name }}
@@ -55,7 +69,7 @@ spec:
     spec:
       containers:
         - name: {{ svc_name }}
-          image: mariadb:{{ version }}
+          image: {{ service_image }}
           env:
 {% for item in secret_env %}
             - name: {{ item.name }}
@@ -64,15 +78,15 @@ spec:
                   name: {{ secret_name }}
                   key: {{ item.name }}
 {% endfor %}
-            - name: MYSQL_DATABASE
-              value: {{ mariadb_database }}
-            - name: MYSQL_USER
-              value: {{ mariadb_user }}
+{% for item in service_env | default([]) %}
+            - name: {{ item.name }}
+              value: {{ item.value }}
+{% endfor %}
           ports:
-            - containerPort: 3306
+            - containerPort: {{ container_port }}
           volumeMounts:
             - name: data
-              mountPath: /var/lib/mysql
+              mountPath: {{ volume_mount_path }}
 {% if file_secrets %}
 {% for secret in file_secrets %}
             - name: secret-files
@@ -104,11 +118,11 @@ spec:
             successThreshold: 1
           resources:
             requests:
-              memory: {{ mariadb_memory }}Mi
-              cpu: {{ mariadb_cores * 1000 }}m
+              memory: {{ memory_request }}Mi
+              cpu: {{ (cpu_cores * 1000) | int }}m
             limits:
-              memory: {{ mariadb_memory }}Mi
-              cpu: {{ mariadb_cores * 1000 }}m
+              memory: {{ memory_request }}Mi
+              cpu: {{ (cpu_cores * 1000) | int }}m
       volumes:
         - name: data
           persistentVolumeClaim:
@@ -133,6 +147,6 @@ spec:
   selector:
     app: {{ svc_name }}
   ports:
-    - port: 3306
-      targetPort: 3306
+    - port: {{ service_port }}
+      targetPort: {{ container_port }}
   type: ClusterIP

--- a/templates/podman.yml.j2
+++ b/templates/podman.yml.j2
@@ -1,8 +1,4 @@
-{% set default_secret_env = [
-  {'name': 'MYSQL_ROOT_PASSWORD', 'value': mariadb_root_password},
-  {'name': 'MYSQL_PASSWORD', 'value': mariadb_user_password}
-] %}
-{% set secret_env = secrets.env if secrets is defined and secrets.env is not none and secrets.env | length > 0 else default_secret_env %}
+{% set secret_env = secrets.env if secrets is defined and secrets.env is not none and secrets.env | length > 0 else [] %}
 {% set file_secrets = secrets.files if secrets is defined and secrets.files is not none and secrets.files | length > 0 else [] %}
 {% set quadlet_scope_value = quadlet_scope | default('system') %}
 {% if quadlet_scope_value == 'user' %}
@@ -10,28 +6,36 @@
 {% else %}
 {% set quadlet_base_dir = '/etc/containers/systemd' %}
 {% endif %}
-{% set env_file_path = quadlet_base_dir ~ '/' ~ mariadb_hostname ~ '.env' %}
+{% set env_file_path = quadlet_base_dir ~ '/' ~ (service_name | default(service_id)) ~ '.env' %}
 {% set secret_dir = quadlet_base_dir ~ '/secrets' %}
+{% set ports = service_ports | default((service_port is defined) | ternary([service_port], [])) %}
+{% set volumes = service_volumes | default([]) %}
+{% set inline_env = service_env | default([]) %}
 [Unit]
-Description=MariaDB Database
+Description={{ service_unit_description | default('Managed container for ' ~ (service_name | default(service_id))) }}
 After=network-online.target
 Wants=network-online.target
 
 [Container]
-Image=docker.io/library/mariadb:{{ version }}
-ContainerName={{ mariadb_hostname }}
+Image={{ service_image }}
+ContainerName={{ service_name | default(service_id) }}
 AutoUpdate=registry
-Environment=MYSQL_DATABASE={{ mariadb_database }}
-Environment=MYSQL_USER={{ mariadb_user }}
+{% for env in inline_env %}
+Environment={{ env.name }}={{ env.value }}
+{% endfor %}
 {% if secret_env %}
 EnvironmentFile={{ env_file_path }}
 {% endif %}
-Volume=mariadb-data.volume:/var/lib/mysql:Z
-PublishPort={{ mariadb_ip }}:3306:3306
+{% for vol in volumes %}
+Volume={{ vol.source | default(vol.name) }}.volume:{{ vol.target }}:{% if vol.mode is defined %}{{ vol.mode }}{% else %}Z{% endif %}
+{% endfor %}
 {% for secret in file_secrets %}
 Volume={{ secret_dir }}/{{ secret.name }}:{{ secret.target | default('/run/secrets/' ~ secret.name) }}:ro,Z
 {% endfor %}
-HealthCmd={{ (health.cmd | default(['mysqladmin', 'ping', '-h', 'localhost'])) | join(' ') }}
+{% for port in ports %}
+PublishPort={{ port.host_ip | default('') }}{% if port.host_ip is defined and port.host_ip | string | length > 0 %}:{% endif %}{{ port.published | default(port.target) }}:{{ port.target }}{% if port.protocol is defined %}/{{ port.protocol }}{% endif %}
+{% endfor %}
+HealthCmd={{ (health.cmd | default(['true'])) | join(' ') }}
 HealthInterval={{ health.interval | default('10s') }}
 HealthTimeout={{ health.timeout | default('5s') }}
 HealthRetries={{ health.retries | default(3) }}

--- a/templates/proxmox.yml.j2
+++ b/templates/proxmox.yml.j2
@@ -1,33 +1,43 @@
 ---
-container_ip: "{{ mariadb_ip }}"
+{% set container = service_container | default({}) %}
+{% set pkg_list = service_packages | default([]) %}
+{% set file_list = service_files | default([]) %}
+{% set svc_list = service_services | default([]) %}
+{% set cmd_list = service_commands | default([]) %}
+container_ip: "{{ service_ip }}"
 container:
-  vmid: "{{ mariadb_container_id }}"
-  hostname: "{{ mariadb_hostname }}"
-  ostemplate: "{{ proxmox_template | default('local:vztmpl/ubuntu-24.04-standard_24.04-2_amd64.tar.zst') }}"
-  disk: "{{ mariadb_storage_gb }}"
-  cores: "{{ mariadb_cores }}"
-  memory: "{{ mariadb_memory }}"
-  swap: "{{ mariadb_memory }}"
+  vmid: "{{ container.vmid | default(service_id) }}"
+  hostname: "{{ container.hostname | default(service_name | default(service_id)) }}"
+  ostemplate: "{{ container.ostemplate | default(proxmox_template | default('local:vztmpl/ubuntu-24.04-standard_24.04-2_amd64.tar.zst')) }}"
+  disk: "{{ container.disk | default(service_storage_gb | default(10)) }}"
+  cores: "{{ container.cores | default(service_resources.cpu_cores | default(1)) }}"
+  memory: "{{ container.memory | default(service_resources.memory_mb | default(512)) }}"
+  swap: "{{ container.swap | default(service_resources.memory_mb | default(512)) }}"
   netif:
-    net0: "name=eth0,bridge=vmbr0,ip={{ mariadb_ip }}/24,gw={{ gateway }}"
-  onboot: yes
-  unprivileged: yes
-  features: "nesting=1,keyctl=1"
+    net0: "name={{ container.interface | default('eth0') }},bridge={{ container.bridge | default('vmbr0') }},ip={{ service_ip }}/{{ container.cidr | default(24) }}{% if container.gateway is defined %},gw={{ container.gateway }}{% elif service_gateway is defined %},gw={{ service_gateway }}{% endif %}"
+  onboot: {{ container.onboot | default('yes') }}
+  unprivileged: {{ container.unprivileged | default('yes') }}
+  features: "{{ container.features | default('nesting=1,keyctl=1') }}"
 
 setup:
-  packages:
-    - mariadb-server
-    - mariadb-client
-    - python3-pymysql
-
-  config:
-    - path: /etc/mysql/mariadb.conf.d/99-custom.cnf
+  packages:{% if pkg_list | length == 0 %} []{% else %}
+{% for pkg in pkg_list %}
+    - {{ pkg }}
+{% endfor %}{% endif %}
+  config:{% if file_list | length == 0 %} []{% else %}
+{% for item in file_list %}
+    - path: {{ item.path }}
       content: |
-        [mysqld]
-        bind-address = {{ mariadb_bind_address | default(container_ip) }}
-        max_connections = 200
-
-  services:
-    - name: mariadb
-      enabled: true
-      state: started
+{{ item.content | indent(8, true) }}{% if item.mode is defined %}
+      mode: {{ item.mode }}{% endif %}
+{% endfor %}{% endif %}
+  services:{% if svc_list | length == 0 %} []{% else %}
+{% for svc in svc_list %}
+    - name: {{ svc.name }}
+      enabled: {{ svc.enabled | default(true) | ternary(true, false) }}
+      state: {{ svc.state | default('started') }}
+{% endfor %}{% endif %}
+  commands:{% if cmd_list | length == 0 %} []{% else %}
+{% for cmd in cmd_list %}
+    - {{ cmd }}
+{% endfor %}{% endif %}

--- a/tests/sample_service.yml
+++ b/tests/sample_service.yml
@@ -1,13 +1,67 @@
-service_id: mariadb
+service_id: example-db
+service_name: example-db
+service_unit_name: example-db
+service_image: docker.io/library/mariadb:10.11
 version: "10.11"
-
-runtime_templates:
-  proxmox: templates/proxmox.yml.j2
-  docker: templates/docker.yml.j2
-  podman: templates/podman.yml.j2
-  kubernetes: templates/kubernetes.yml.j2
-  baremetal: templates/baremetal.yml.j2
-
+service_ip: 192.0.2.50
+service_ports:
+  - target: 3306
+    published: 3306
+    host_ip: 192.0.2.50
+service_env:
+  - name: MYSQL_DATABASE
+    value: sampledb
+  - name: MYSQL_USER
+    value: sample
+service_volumes:
+  - name: data
+    source: example-db-data
+    target: /var/lib/mysql
+    driver: local
+service_packages:
+  - mariadb-server
+  - mariadb-client
+service_files:
+  - path: /etc/example-db/config.env
+    mode: '0640'
+    content: |
+      MYSQL_DATABASE=sampledb
+      MYSQL_USER=sample
+service_services:
+  - name: example-db
+    enabled: true
+    state: started
+service_commands:
+  - /usr/bin/true
+service_resources:
+  memory_mb: 512
+  cpu_cores: 1
+service_namespace: sample
+service_replicas: 1
+service_storage_gb: 10
+service_gateway: 192.0.2.1
+service_container:
+  vmid: 200
+  hostname: example-db
+  ostemplate: local:vztmpl/ubuntu-24.04-standard_24.04-2_amd64.tar.zst
+  disk: 10
+  cores: 1
+  memory: 512
+  swap: 512
+  bridge: vmbr0
+  cidr: 24
+  gateway: 192.0.2.1
+  interface: eth0
+  onboot: yes
+  unprivileged: yes
+  features: nesting=1,keyctl=1
+exports:
+  env:
+    - name: DATABASE_HOST
+      value: 192.0.2.50
+storage:
+  - name: data
+    path: /var/lib/mysql
 health:
   cmd:
     - mysqladmin
@@ -19,32 +73,12 @@ health:
   interval: 10s
   timeout: 5s
   retries: 3
-
-mariadb_hostname: mariadb-sample
-mariadb_container_id: 200
-mariadb_ip: 192.0.2.50
-mariadb_storage_gb: 10
-mariadb_memory: 512
-mariadb_cores: 1
-mariadb_database: sampledb
-mariadb_user: sample
-mariadb_root_password: sample-root
-mariadb_user_password: sample-user
-mariadb_allowed_hosts:
-  - 192.0.2.10
-mariadb_bind_address: 192.0.2.50
-
-proxmox_template: local:vztmpl/ubuntu-24.04-standard_24.04-2_amd64.tar.zst
-gateway: 192.0.2.1
-proxmox_node: pve
-proxmox_api_user: test@pam
-proxmox_api_password: password
-proxmox_api_host: proxmox.local
-
-k8s_namespace: sample
-mariadb_replicas: 1
-quadlet_scope: system
-
+runtime_templates:
+  proxmox: templates/proxmox.yml.j2
+  docker: templates/docker.yml.j2
+  podman: templates/podman.yml.j2
+  kubernetes: templates/kubernetes.yml.j2
+  baremetal: templates/baremetal.yml.j2
 secrets:
   env:
     - name: MYSQL_ROOT_PASSWORD
@@ -54,5 +88,5 @@ secrets:
   files:
     - name: ca-cert
       value: "-----BEGIN CERTIFICATE-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA\n-----END CERTIFICATE-----"
-      target: /etc/mysql/certs/ca.pem
+      target: /etc/example-db/certs/ca.pem
       mode: '0400'


### PR DESCRIPTION
## Summary
- replace MariaDB-specific handlers and runtime tasks with generic service variables
- update runtime templates to iterate over service metadata instead of hardcoding MariaDB defaults
- expand the service schema and sample contract to document the new generic fields

## Testing
- `ansible-playbook tests/render.yml` *(fails: command not found: ansible-playbook)*

------
https://chatgpt.com/codex/tasks/task_e_68f3d0371a74832eb4cde217a76d1b39