### PR TITLE
Generalize sample service and harden infrastructure tooling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,14 @@ on:
 
 jobs:
   lint-and-validate:
+    name: "Lint and validate (${{ matrix.lane }})"
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        lane: [stable, latest]
+    env:
+      SAMPLE_SERVICE_ID: sample-service
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -23,16 +30,22 @@ jobs:
           pip install ansible ansible-lint yamllint jsonschema pyyaml
 
       - name: Install Ansible collections
-        run: |
-          ansible-galaxy collection install community.general community.docker community.mysql kubernetes.core
+        run: ansible-galaxy collection install -r ci/collections-${{ matrix.lane }}.yml
 
       - name: Verify Docker Compose availability
         run: docker compose version
 
-      - name: Set up kubectl
+      - name: Set up kubectl (stable)
+        if: matrix.lane == 'stable'
         uses: azure/setup-kubectl@v3
         with:
           version: 'v1.29.3'
+
+      - name: Set up kubectl (latest)
+        if: matrix.lane == 'latest'
+        uses: azure/setup-kubectl@v3
+        with:
+          version: 'latest'
 
       - name: Validate schema definition
         run: python ci/validate_schema.py
@@ -48,28 +61,28 @@ jobs:
         run: ansible-playbook tests/render.yml -e runtime=proxmox
 
       - name: Validate Proxmox manifest
-        run: yamllint /tmp/ansible-runtime/mariadb/proxmox.yml
+        run: yamllint /tmp/ansible-runtime/${{ env.SAMPLE_SERVICE_ID }}/proxmox.yml
 
       - name: Render Docker Compose configuration
         run: ansible-playbook tests/render.yml -e runtime=docker
 
       - name: Validate Docker Compose manifest
-        run: docker compose -f /tmp/ansible-runtime/mariadb/docker.yml config
+        run: docker compose -f /tmp/ansible-runtime/${{ env.SAMPLE_SERVICE_ID }}/docker.yml config
 
       - name: Render Podman Quadlet configuration
         run: ansible-playbook tests/render.yml -e runtime=podman
 
       - name: Validate Quadlet unit
-        run: systemd-analyze verify /tmp/ansible-runtime/mariadb/podman.yml
+        run: systemd-analyze verify /tmp/ansible-runtime/${{ env.SAMPLE_SERVICE_ID }}/podman.yml
 
       - name: Render bare-metal systemd configuration
         run: ansible-playbook tests/render.yml -e runtime=baremetal
 
       - name: Validate systemd unit
-        run: systemd-analyze verify /tmp/ansible-runtime/mariadb/baremetal.yml
+        run: systemd-analyze verify /tmp/ansible-runtime/${{ env.SAMPLE_SERVICE_ID }}/baremetal.yml
 
       - name: Render Kubernetes manifests
         run: ansible-playbook tests/render.yml -e runtime=kubernetes
 
       - name: Validate Kubernetes manifest
-        run: kubectl apply --dry-run=client --validate=true -f /tmp/ansible-runtime/mariadb/kubernetes.yml
+        run: kubectl apply --dry-run=client --validate=true -f /tmp/ansible-runtime/${{ env.SAMPLE_SERVICE_ID }}/kubernetes.yml

--- a/ci/collections-latest.yml
+++ b/ci/collections-latest.yml
@@ -1,0 +1,5 @@
+collections:
+  - name: community.general
+  - name: community.docker
+  - name: community.mysql
+  - name: kubernetes.core

--- a/ci/collections-stable.yml
+++ b/ci/collections-stable.yml
@@ -1,0 +1,9 @@
+collections:
+  - name: community.general
+    version: 7.5.0
+  - name: community.docker
+    version: 3.4.10
+  - name: community.mysql
+    version: 3.7.3
+  - name: kubernetes.core
+    version: 5.0.0

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,14 +1,14 @@
 # Self-Hosted Infrastructure Framework
 
-A runtime-agnostic infrastructure-as-code framework for deploying self-hosted applications across **Proxmox LXC**, **Docker Compose**, **Podman Quadlets**, **Kubernetes**, and **bare-metal systemd** from a single service definition.
+A runtime-agnostic infrastructure-as-code framework for deploying self-hosted applications across **Proxmox LXC**, **Docker Compose**, **Podman Quadlets**, **Kubernetes**, and **bare-metal systemd** from a single service contract.
 
 ## Key Features
 
-- **Write Once, Deploy Anywhere** – shared service contract rendered into runtime-specific manifests.
-- **Runtime-Aware Secrets Delivery** – environment secrets use Compose env files, Quadlet environment files, Kubernetes Secrets, and Ansible modules for MariaDB provisioning.
-- **Safety-First Defaults** – LXC containers declare `container_ip`, bind MariaDB to that address, and restrict database users to explicit hosts.
-- **Unified Health Contract** – one `health.cmd` entry drives Compose healthchecks, Quadlet probes, Kubernetes readiness/liveness probes, and a post-deploy gate.
-- **Continuous Validation** – GitHub Actions lint Ansible/YAML, render every runtime, and verify the generated artifacts.
+- **Write Once, Deploy Anywhere** – render the same service definition into runtime-specific manifests and unit files.
+- **Portable Secrets Handling** – ship environment and file-based secrets with runtime-appropriate permissions, optionally shredding rendered material after adapters finish.
+- **Declarative Service Exports** – advertise connection details (for example URLs, ports, or credentials) through `exports.env` so downstream apps can consume them without service-specific wiring in this repository.
+- **Unified Health Contract** – a single `health.cmd` drives Compose healthchecks, Quadlet probes, Kubernetes readiness/liveness probes, and a post-deploy gate.
+- **Continuous Validation** – GitHub Actions lint Ansible/YAML, render every runtime, and verify the generated artifacts with the runtime CLIs.
 
 ## Quick Start
 
@@ -16,7 +16,7 @@ A runtime-agnostic infrastructure-as-code framework for deploying self-hosted ap
 
 ```bash
 pip install ansible ansible-lint yamllint jsonschema pyyaml
-ansible-galaxy collection install community.general community.docker community.mysql kubernetes.core
+ansible-galaxy collection install -r ci/collections-stable.yml
 ```
 
 ### Render a runtime locally
@@ -37,10 +37,10 @@ The rendered manifest is written to `/tmp/ansible-runtime/<service_id>/<runtime>
 
 ## Service Contract Essentials
 
-Service defaults should include a `secrets` block so the renderer can deliver runtime-specific secret material. Example:
+Every service definition must provide identifiers, runtime templates, health checks, storage, and exports. A minimal example using the bundled `sample_service.yml` looks like:
 
 ```yaml
-service_id: mariadb
+service_id: sample-service
 runtime_templates:
   docker: templates/docker.yml.j2
   podman: templates/podman.yml.j2
@@ -48,23 +48,49 @@ runtime_templates:
   kubernetes: templates/kubernetes.yml.j2
   baremetal: templates/baremetal.yml.j2
 
-secrets:
+exports:
   env:
-    - name: MYSQL_ROOT_PASSWORD
-      value: "{{ mariadb_root_password }}"
-    - name: MYSQL_PASSWORD
-      value: "{{ mariadb_user_password }}"
+    - name: SAMPLE_SERVICE_URL
+      value: https://sample-service.internal
+      description: Base URL consumers should call.
+
+secrets:
+  shred_after_apply: true
+  env:
+    - name: SAMPLE_SERVICE_TOKEN
+      value: "{{ sample_service_token }}"
   files:
-    - name: ca-cert
-      target: /etc/mysql/certs/ca.pem
-      value: "{{ mariadb_ca_certificate }}"
+    - name: tls-cert
+      target: /etc/sample-service/certs/tls.crt
+      value: "{{ sample_service_tls_cert }}"
 ```
 
-Additional variables consumed by the adapters include:
+Downstream applications consume these exports by resolving them through a dependency registry shared between repositories. Provide the registry as a list of known dependencies either inline (`dependency_registry`) or via `dependency_registry_file`:
 
-- `mariadb_allowed_hosts` – list of hostnames or IPs granted access (defaults to the service bind address).
-- `mariadb_bind_address` – explicit bind address for MariaDB; defaults to the rendered `container_ip` for LXC.
-- `quadlet_scope` – `system` (default) or `user` to control where Quadlet units are installed.
+```yaml
+# dependency-registry.yml
+dependencies:
+  - sample-service
+  - shared-cache
+```
+
+A dependent service can then declare its expectations and map resolved values (for example through a `dependency_exports` variable populated from the registry and exported environment files):
+
+```yaml
+requires:
+  - sample-service
+
+service_env:
+  - name: UPSTREAM_URL
+    value: "{{ dependency_exports['sample-service'].SAMPLE_SERVICE_URL }}"
+```
+
+The registry keeps validation decoupled from the Ansible inventory while ensuring every declared dependency is fulfilled by an exported contract.
+
+## Additional Options
+
+- `quadlet_scope` – set to `system` (default) or `user` to control where Quadlet units are installed. When using `quadlet_scope: user`, make sure lingering is enabled for the target user or user services are explicitly started at boot.
+- `secrets.shred_after_apply` – remove rendered secret files and env files immediately after the runtime adapter applies changes, leaving only in-memory material behind.
 
 ## Continuous Integration
 

--- a/docs/baremetal.md
+++ b/docs/baremetal.md
@@ -1,49 +1,46 @@
 # Bare-Metal systemd Deployment Guide
 
-Deploy MariaDB directly on bare-metal or virtual machines with idempotent configuration and secure defaults.
+Deploy services directly on bare-metal or virtual machines with idempotent configuration and generic systemd units.
 
 ## Highlights
 
 - Packages installed via non-interactive APT (`DEBIAN_FRONTEND=noninteractive`).
-- `/etc/mysql/mariadb.conf.d/99-custom.cnf` is managed to bind MariaDB to `mariadb_bind_address`.
-- Handlers restart MariaDB whenever configuration or unit files change.
-- Database provisioning uses `community.mysql` modules for password, database, and user management—no shell commands.
-- `mariadb_allowed_hosts` must list specific client hosts; `%` is rejected.
+- Configuration files defined in the service contract render exactly once and trigger handlers when changed.
+- Generated units inherit defaults from `templates/baremetal.yml.j2`, keeping runtime-agnostic settings consistent.
 
 ## Prerequisites
 
 ```bash
 sudo apt update
-sudo apt install mariadb-server python3-pymysql
-ansible-galaxy collection install community.mysql
+sudo apt install systemd
+ansible-galaxy collection install community.general
 ```
 
 ## Workflow
 
 1. Render the systemd unit (`templates/baremetal.yml.j2`) using the shared contract.
 2. Apply with `roles/common/apply_runtime/tasks/baremetal.yml`, which:
-   - Sets `service_ip` based on `mariadb_bind_address`.
-   - Installs required packages.
-   - Writes `99-custom.cnf` and triggers the shared handler on change.
+   - Installs required packages via APT when declared.
+   - Writes configuration files with their requested permissions.
    - Places the rendered unit at `/etc/systemd/system/<service_id>.service`.
-   - Enables and starts the service.
-   - Secures the root account and grants users access via `community.mysql`.
+   - Enables and starts the service, then runs the shared health command.
 
 ## Variables
 
-- `mariadb_bind_address` – defaults to the host’s primary address; override to constrain network exposure.
-- `mariadb_allowed_hosts` – list of client addresses. Provide a list (e.g. `['10.0.0.10']`).
+- `service_unit` – override description, dependencies, or the `[Service]` stanza for advanced workloads.
+- `service_packages` – list of packages to install before enabling the unit.
+- `secrets.shred_after_apply` – available to keep secret files ephemeral when combined with runtime adapters that create them locally.
 
 ## Validation
 
 After rendering:
 
 ```bash
-systemd-analyze verify /tmp/ansible-runtime/mariadb/baremetal.yml
+systemd-analyze verify /tmp/ansible-runtime/sample-service/baremetal.yml
 ```
 
 Run the playbook and rely on the shared health command for a final check:
 
 ```bash
-ansible-playbook playbooks/deploy-mariadb.yml -e runtime=baremetal -e "health.cmd=['mysqladmin','ping','-h','127.0.0.1']"
+ansible-playbook playbooks/deploy-sample.yml -e runtime=baremetal -e "health.cmd=['/bin/sh','-c','exit 0']"
 ```

--- a/roles/common/apply_runtime/tasks/docker.yml
+++ b/roles/common/apply_runtime/tasks/docker.yml
@@ -3,6 +3,8 @@
   set_fact:
     compose_secret_env: "{{ secrets.env if secrets is defined and secrets.env is not none and secrets.env | length > 0 else [] }}"
     compose_secret_files: "{{ secrets.files if secrets is defined and secrets.files is not none and secrets.files | length > 0 else [] }}"
+    compose_secret_env_path: "{{ runtime_output_dir }}/{{ service_name | default(service_id) }}.env"
+    compose_secret_shred: "{{ secrets.shred_after_apply | default(false) if secrets is defined else false }}"
 
 - name: Write Compose secret environment file
   copy:
@@ -38,6 +40,31 @@
       - "{{ runtime_config_path | basename }}"
     state: present
     pull: always
+
+- name: Remove Compose secret environment file after apply
+  file:
+    path: "{{ compose_secret_env_path }}"
+    state: absent
+  when:
+    - compose_secret_shred | bool
+    - compose_secret_env | length > 0
+
+- name: Remove Compose secret files after apply
+  file:
+    path: "{{ runtime_output_dir }}/secrets/{{ item.name }}"
+    state: absent
+  loop: "{{ compose_secret_files }}"
+  when:
+    - compose_secret_shred | bool
+    - compose_secret_files | length > 0
+
+- name: Remove Compose secret directory after apply
+  file:
+    path: "{{ runtime_output_dir }}/secrets"
+    state: absent
+  when:
+    - compose_secret_shred | bool
+    - compose_secret_files | length > 0
 
 - name: Set service IP for health checks
   set_fact:

--- a/roles/common/apply_runtime/tasks/podman.yml
+++ b/roles/common/apply_runtime/tasks/podman.yml
@@ -14,6 +14,7 @@
   set_fact:
     quadlet_secret_env: "{{ secrets.env if secrets is defined and secrets.env is not none and secrets.env | length > 0 else [] }}"
     quadlet_secret_files: "{{ secrets.files if secrets is defined and secrets.files is not none and secrets.files | length > 0 else [] }}"
+    quadlet_secret_shred: "{{ secrets.shred_after_apply | default(false) if secrets is defined else false }}"
 
 - name: Deduplicate quadlet secret environment variables
   set_fact:
@@ -76,6 +77,35 @@
     enabled: yes
     state: started
     scope: "{{ quadlet_effective_scope }}"
+
+- name: Remove Quadlet environment file after apply
+  file:
+    path: "{{ quadlet_env_path }}"
+    state: absent
+  when:
+    - quadlet_secret_shred | bool
+    - quadlet_secret_env | length > 0
+  become: {{ (quadlet_effective_scope == 'system') | bool }}
+
+- name: Remove Quadlet secret files after apply
+  file:
+    path: "{{ quadlet_secret_dir }}/{{ item.name }}"
+    state: absent
+  loop: "{{ quadlet_secret_files }}"
+  when:
+    - quadlet_secret_shred | bool
+    - quadlet_secret_files | length > 0
+  no_log: true
+  become: {{ (quadlet_effective_scope == 'system') | bool }}
+
+- name: Remove Quadlet secret directory after apply
+  file:
+    path: "{{ quadlet_secret_dir }}"
+    state: absent
+  when:
+    - quadlet_secret_shred | bool
+    - quadlet_secret_files | length > 0
+  become: {{ (quadlet_effective_scope == 'system') | bool }}
 
 - name: Set service IP for health checks
   set_fact:

--- a/roles/common/validate_schema/tasks/main.yml
+++ b/roles/common/validate_schema/tasks/main.yml
@@ -15,11 +15,60 @@
       - runtime_templates is defined
     fail_msg: "Service {{ service_id | default('unknown') }} is missing required contract fields"
 
+- name: Initialize dependency registry
+  set_fact:
+    dependency_registry_entries: []
+
+- name: Load dependency registry from file
+  set_fact:
+    dependency_registry_source: "{{ lookup('file', dependency_registry_file) | from_yaml }}"
+  when: dependency_registry_file is defined
+
+- name: Normalize dependency registry from file
+  set_fact:
+    dependency_registry_entries: >-
+      {{
+        dependency_registry_entries
+        + (
+          dependency_registry_source.dependencies
+          if (dependency_registry_source is mapping and dependency_registry_source.dependencies is defined)
+          else (
+            dependency_registry_source.keys() | list
+            if dependency_registry_source is mapping
+            else (
+              [dependency_registry_source]
+              if dependency_registry_source is string
+              else (dependency_registry_source | default([]))
+            )
+          )
+        )
+      }}
+  when: dependency_registry_file is defined
+
+- name: Append inline dependency registry entries
+  set_fact:
+    dependency_registry_entries: >-
+      {{
+        dependency_registry_entries
+        + (
+          [dependency_registry]
+          if dependency_registry is string
+          else (dependency_registry | default([]))
+        )
+      }}
+  when: dependency_registry is defined
+
+- name: Deduplicate dependency registry entries
+  set_fact:
+    dependency_registry_entries: "{{ dependency_registry_entries | default([]) | unique }}"
+
 - name: Validate required dependencies exist
   assert:
     that:
-      - item in groups['all'] or item == service_id
-    fail_msg: "Required dependency {{ item }} not found in inventory"
+      - item in dependency_registry_entries
+    fail_msg: >-
+      Required dependency {{ item }} not found in dependency registry. Provide
+      dependency_registry or dependency_registry_file with available exports.
   loop: "{{ requires | default([]) }}"
   when: requires is defined and requires | length > 0
 

--- a/schemas/service.schema.yml
+++ b/schemas/service.schema.yml
@@ -190,6 +190,13 @@ properties:
         items:
           type: object
           required: [name, value]
+          properties:
+            name:
+              type: string
+            value:
+              type: string
+            description:
+              type: string
   storage:
     type: array
     items:
@@ -210,6 +217,8 @@ properties:
   secrets:
     type: object
     properties:
+      shred_after_apply:
+        type: boolean
       env:
         type: array
         items:

--- a/tests/sample_service.yml
+++ b/tests/sample_service.yml
@@ -1,34 +1,33 @@
-service_id: example-db
-service_name: example-db
-service_unit_name: example-db
-service_image: docker.io/library/mariadb:10.11
-version: "10.11"
+service_id: sample-service
+service_name: sample-service
+service_unit_name: sample-service
+service_image: docker.io/library/nginx:1.27
+version: "1.27"
 service_ip: 192.0.2.50
 service_ports:
-  - target: 3306
-    published: 3306
+  - target: 8080
+    published: 8080
     host_ip: 192.0.2.50
 service_env:
-  - name: MYSQL_DATABASE
-    value: sampledb
-  - name: MYSQL_USER
-    value: sample
+  - name: APP_MODE
+    value: production
+  - name: APP_FEATURE_FLAG
+    value: "true"
 service_volumes:
-  - name: data
-    source: example-db-data
-    target: /var/lib/mysql
+  - name: config
+    source: sample-service-config
+    target: /etc/sample-service
     driver: local
 service_packages:
-  - mariadb-server
-  - mariadb-client
+  - nginx
 service_files:
-  - path: /etc/example-db/config.env
+  - path: /etc/sample-service/runtime.env
     mode: '0640'
     content: |
-      MYSQL_DATABASE=sampledb
-      MYSQL_USER=sample
+      APP_MODE=production
+      APP_FEATURE_FLAG=true
 service_services:
-  - name: example-db
+  - name: sample-service
     enabled: true
     state: started
 service_commands:
@@ -38,13 +37,13 @@ service_resources:
   cpu_cores: 1
 service_namespace: sample
 service_replicas: 1
-service_storage_gb: 10
+service_storage_gb: 5
 service_gateway: 192.0.2.1
 service_container:
   vmid: 200
-  hostname: example-db
+  hostname: sample-service
   ostemplate: local:vztmpl/ubuntu-24.04-standard_24.04-2_amd64.tar.zst
-  disk: 10
+  disk: 5
   cores: 1
   memory: 512
   swap: 512
@@ -57,19 +56,19 @@ service_container:
   features: nesting=1,keyctl=1
 exports:
   env:
-    - name: DATABASE_HOST
-      value: 192.0.2.50
+    - name: SAMPLE_SERVICE_URL
+      value: https://sample-service.internal
+      description: Base URL for dependent services
+    - name: SAMPLE_SERVICE_PORT
+      value: "8080"
 storage:
-  - name: data
-    path: /var/lib/mysql
+  - name: config
+    path: /etc/sample-service
 health:
   cmd:
-    - mysqladmin
-    - ping
-    - -h
-    - 127.0.0.1
-    - -P
-    - "3306"
+    - /bin/sh
+    - -c
+    - "exit 0"
   interval: 10s
   timeout: 5s
   retries: 3
@@ -80,13 +79,12 @@ runtime_templates:
   kubernetes: templates/kubernetes.yml.j2
   baremetal: templates/baremetal.yml.j2
 secrets:
+  shred_after_apply: false
   env:
-    - name: MYSQL_ROOT_PASSWORD
-      value: sample-root
-    - name: MYSQL_PASSWORD
-      value: sample-user
+    - name: SAMPLE_SERVICE_TOKEN
+      value: super-secret-token
   files:
-    - name: ca-cert
-      value: "-----BEGIN CERTIFICATE-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA\n-----END CERTIFICATE-----"
-      target: /etc/example-db/certs/ca.pem
+    - name: tls-cert
+      value: "-----BEGIN CERTIFICATE-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAtestcertificate\n-----END CERTIFICATE-----"
+      target: /etc/sample-service/certs/tls.crt
       mode: '0400'


### PR DESCRIPTION
## Summary
- replace the MariaDB-first documentation with a generic sample service and document exports, dependency registries, and quadlet scope requirements
- tighten dependency validation and secrets handling while expanding the schema to describe exports and optional shredding
- pin ansible collections and kubectl in CI with a stable/latest matrix and refresh the bundled sample service data

## Testing
- not run (ansible-playbook unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68f3d3bc63b4832e8c00d9e06299812a