### PR TITLE
Tighten host hardening defaults

### DIFF
--- a/roles/system_hardening/defaults/main.yml
+++ b/roles/system_hardening/defaults/main.yml
@@ -37,6 +37,11 @@ hardening_umask_targets:
 hardening_aide_db_path: /var/lib/aide/aide.db.gz
 hardening_aide_new_db_path: /var/lib/aide/aide.db.new.gz
 hardening_firewalld_zone: public
-hardening_firewalld_services:
-  - cockpit
+hardening_firewalld_services: []
 hardening_firewalld_ports: []
+hardening_requiretty_exempt_users: []
+hardening_security_tool_logrotate_frequency: weekly
+hardening_security_tool_logrotate_rotate: 8
+hardening_security_tool_scan_minute: 30
+hardening_security_tool_scan_hour: 2
+hardening_security_tool_scan_weekday: 0

--- a/roles/system_hardening/tasks/common.yml
+++ b/roles/system_hardening/tasks/common.yml
@@ -78,10 +78,9 @@
   notify: Validate sudoers configuration
 
 - name: Require TTY for sudo invocations
-  ansible.builtin.copy:
+  ansible.builtin.template:
+    src: sudo_requiretty.j2
     dest: /etc/sudoers.d/requiretty
-    content: |-
-      Defaults requiretty
     owner: root
     group: root
     mode: '0440'
@@ -113,6 +112,52 @@
     user: root
     job: /usr/bin/aide --check
     state: present
+
+- name: Configure log rotation for security tooling
+  ansible.builtin.template:
+    src: security_tools_logrotate.j2
+    dest: /etc/logrotate.d/hardening-security-tools
+    owner: root
+    group: root
+    mode: '0644'
+  when: >-
+    ansible_facts.packages.get('clamav') is defined or
+    ansible_facts.packages.get('clamav-daemon') is defined or
+    ansible_facts.packages.get('clamav-update') is defined or
+    ansible_facts.packages.get('clamd') is defined or
+    ansible_facts.packages.get('rkhunter') is defined or
+    ansible_facts.packages.get('chkrootkit') is defined
+
+- name: Ensure chkrootkit log directory exists
+  ansible.builtin.file:
+    path: /var/log/chkrootkit
+    state: directory
+    owner: root
+    group: root
+    mode: '0750'
+  when: ansible_facts.packages.get('chkrootkit') is defined
+
+- name: Schedule rkhunter scans during the maintenance window
+  ansible.builtin.cron:
+    name: RKHunter maintenance scan
+    minute: "{{ hardening_security_tool_scan_minute }}"
+    hour: "{{ hardening_security_tool_scan_hour }}"
+    weekday: "{{ hardening_security_tool_scan_weekday }}"
+    user: root
+    job: /usr/bin/rkhunter --cronjob --quiet --report-warnings-only
+    state: present
+  when: ansible_facts.packages.get('rkhunter') is defined
+
+- name: Schedule chkrootkit scans during the maintenance window
+  ansible.builtin.cron:
+    name: chkrootkit maintenance scan
+    minute: "{{ hardening_security_tool_scan_minute }}"
+    hour: "{{ hardening_security_tool_scan_hour }}"
+    weekday: "{{ hardening_security_tool_scan_weekday }}"
+    user: root
+    job: nice -n 10 /usr/sbin/chkrootkit >> /var/log/chkrootkit/chkrootkit.log 2>&1
+    state: present
+  when: ansible_facts.packages.get('chkrootkit') is defined
 
 - name: Disable unnecessary services
   ansible.builtin.service:

--- a/roles/system_hardening/tasks/debian.yml
+++ b/roles/system_hardening/tasks/debian.yml
@@ -34,13 +34,12 @@
     - ufw default allow outgoing
   changed_when: false
 
-- name: Allow SSH and Cockpit in ufw
+- name: Allow SSH in ufw
   ansible.builtin.command: "ufw allow {{ item }}"
   args:
     warn: false
   loop:
     - "{{ hardening_ssh_port }}/tcp"
-    - 9090/tcp
   changed_when: false
 
 - name: Enable ufw firewall

--- a/roles/system_hardening/tasks/redhat.yml
+++ b/roles/system_hardening/tasks/redhat.yml
@@ -27,7 +27,7 @@
     immediate: true
   when: ansible_facts.packages.get('firewalld') is defined
 
-- name: Allow cockpit service via firewalld
+- name: Allow additional services via firewalld
   ansible.posix.firewalld:
     zone: "{{ hardening_firewalld_zone }}"
     service: "{{ item }}"
@@ -156,16 +156,6 @@
     dest: /var/log/chkrootkit-initial.log
     content: "{{ chkrootkit_run.stdout }}\n{{ chkrootkit_run.stderr }}"
   when: chkrootkit_run is defined and chkrootkit_run.stdout is defined
-
-- name: Schedule weekly chkrootkit scan
-  ansible.builtin.cron:
-    name: Weekly chkrootkit scan
-    minute: 0
-    hour: 2
-    weekday: 0
-    job: "/usr/sbin/chkrootkit > /var/log/chkrootkit-weekly.log 2>&1"
-    user: root
-  when: ansible_facts.packages.get('chkrootkit') is defined
 
 - name: Initialize AIDE database on Red Hat hosts
   ansible.builtin.command: aide --init

--- a/roles/system_hardening/templates/security_tools_logrotate.j2
+++ b/roles/system_hardening/templates/security_tools_logrotate.j2
@@ -1,0 +1,33 @@
+{% set frequency = hardening_security_tool_logrotate_frequency %}
+{% set rotate = hardening_security_tool_logrotate_rotate %}
+{% if ansible_facts.packages.get('clamav') is defined or ansible_facts.packages.get('clamav-daemon') is defined or ansible_facts.packages.get('clamav-update') is defined or ansible_facts.packages.get('clamd') is defined %}
+/var/log/clamav/*.log {
+    {{ frequency }}
+    rotate {{ rotate }}
+    missingok
+    notifempty
+    compress
+    delaycompress
+    sharedscripts
+}
+{% endif %}
+{% if ansible_facts.packages.get('rkhunter') is defined %}
+/var/log/rkhunter.log {
+    {{ frequency }}
+    rotate {{ rotate }}
+    missingok
+    notifempty
+    compress
+    delaycompress
+}
+{% endif %}
+{% if ansible_facts.packages.get('chkrootkit') is defined %}
+/var/log/chkrootkit/chkrootkit.log {
+    {{ frequency }}
+    rotate {{ rotate }}
+    missingok
+    notifempty
+    compress
+    delaycompress
+}
+{% endif %}

--- a/roles/system_hardening/templates/sudo_requiretty.j2
+++ b/roles/system_hardening/templates/sudo_requiretty.j2
@@ -1,0 +1,4 @@
+Defaults requiretty
+{% for user in hardening_requiretty_exempt_users %}
+Defaults:{{ user }} !requiretty
+{% endfor %}


### PR DESCRIPTION
## Summary
- stop automatically exposing Cockpit in host firewalls
- scope sudo requiretty exceptions through a dedicated template variable
- add log rotation and scheduled maintenance windows for security scanners

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68f3db8ac040832e9af91304d9d307c7