### PR TITLE
Harden runtime defaults and cockpit handling

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -90,7 +90,8 @@ The registry keeps validation decoupled from the Ansible inventory while ensurin
 ## Additional Options
 
 - `quadlet_scope` – set to `system` (default) or `user` to control where Quadlet units are installed. When using `quadlet_scope: user`, make sure lingering is enabled for the target user or user services are explicitly started at boot.
-- `secrets.shred_after_apply` – remove rendered secret files and env files immediately after the runtime adapter applies changes, leaving only in-memory material behind.
+- `secrets.shred_after_apply` – defaults to `true` so rendered secret files and env files are shredded once adapters finish. Override with `false` only when persistent copies are required.
+- `hardening_enable_cockpit` – opt-in toggle that installs Cockpit, binds it to `hardening_cockpit_listen_address` (defaults to `127.0.0.1`), and optionally opens UFW 9090 to the addresses listed in `hardening_cockpit_allowed_sources`.
 
 ## Continuous Integration
 

--- a/docs/baremetal.md
+++ b/docs/baremetal.md
@@ -29,7 +29,7 @@ ansible-galaxy collection install community.general
 
 - `service_unit` – override description, dependencies, or the `[Service]` stanza for advanced workloads.
 - `service_packages` – list of packages to install before enabling the unit.
-- `secrets.shred_after_apply` – available to keep secret files ephemeral when combined with runtime adapters that create them locally.
+- `secrets.shred_after_apply` – defaults to `true` so rendered secrets vanish after adapters finish; set it to `false` when you must keep the artifacts.
 
 ## Validation
 

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -72,7 +72,7 @@ networks:
 
 - `secrets.env` entries feed the env file.
 - `secrets.files` entries create files in `secrets/<name>` and populate the Compose `secrets` map.
-- `secrets.shred_after_apply` removes rendered secrets after deployment when set to `true`.
+- `secrets.shred_after_apply` defaults to `true`, removing rendered secrets after deployment unless you explicitly opt out.
 - `service_ports` control host bindings; publish only the ports you intend to expose.
 
 ## Validating the render
@@ -89,7 +89,7 @@ docker compose -f /tmp/ansible-runtime/sample-service/docker.yml config
 
 1. Builds the env file and optional `secrets/` directory under the render output.
 2. Invokes `community.docker.docker_compose_v2` with `pull: always` to keep images fresh.
-3. Optionally shreds rendered secrets when `secrets.shred_after_apply` is enabled.
+3. Shreds rendered secrets by default; set `secrets.shred_after_apply: false` for workloads that must retain them on disk.
 4. Sets `service_ip` for the unified health gate.
 
 Use the shared health command to run a post-deploy verification:

--- a/roles/common/apply_runtime/tasks/docker.yml
+++ b/roles/common/apply_runtime/tasks/docker.yml
@@ -4,7 +4,7 @@
     compose_secret_env: "{{ secrets.env if secrets is defined and secrets.env is not none and secrets.env | length > 0 else [] }}"
     compose_secret_files: "{{ secrets.files if secrets is defined and secrets.files is not none and secrets.files | length > 0 else [] }}"
     compose_secret_env_path: "{{ runtime_output_dir }}/{{ service_name | default(service_id) }}.env"
-    compose_secret_shred: "{{ secrets.shred_after_apply | default(false) if secrets is defined else false }}"
+    compose_secret_shred: "{{ secrets.shred_after_apply | default(true) if secrets is defined else true }}"
 
 - name: Write Compose secret environment file
   copy:

--- a/roles/common/apply_runtime/tasks/podman.yml
+++ b/roles/common/apply_runtime/tasks/podman.yml
@@ -14,7 +14,7 @@
   set_fact:
     quadlet_secret_env: "{{ secrets.env if secrets is defined and secrets.env is not none and secrets.env | length > 0 else [] }}"
     quadlet_secret_files: "{{ secrets.files if secrets is defined and secrets.files is not none and secrets.files | length > 0 else [] }}"
-    quadlet_secret_shred: "{{ secrets.shred_after_apply | default(false) if secrets is defined else false }}"
+    quadlet_secret_shred: "{{ secrets.shred_after_apply | default(true) if secrets is defined else true }}"
 
 - name: Deduplicate quadlet secret environment variables
   set_fact:

--- a/roles/common/apply_runtime/tasks/proxmox.yml
+++ b/roles/common/apply_runtime/tasks/proxmox.yml
@@ -10,6 +10,19 @@
       - lxc_config.container_ip | length > 0
     fail_msg: "Rendered Proxmox configuration must define container_ip"
 
+- name: Validate Proxmox API token configuration
+  assert:
+    that:
+      - proxmox_api_token_id is defined
+      - proxmox_api_token_id | length > 0
+      - proxmox_api_token_secret is defined
+      - proxmox_api_token_secret | length > 0
+      - proxmox_api_host is defined
+      - proxmox_api_host | length > 0
+      - proxmox_node is defined
+      - proxmox_node | length > 0
+    fail_msg: "Proxmox API token credentials (id/secret) and target node must be defined"
+
 - name: Set container IP facts
   set_fact:
     container_ip: "{{ lxc_config.container_ip }}"
@@ -20,8 +33,8 @@
     vmid: "{{ lxc_config.container.vmid }}"
     hostname: "{{ lxc_config.container.hostname }}"
     node: "{{ proxmox_node }}"
-    api_user: "{{ proxmox_api_user }}"
-    api_password: "{{ proxmox_api_password }}"
+    api_token_id: "{{ proxmox_api_token_id }}"
+    api_token_secret: "{{ proxmox_api_token_secret }}"
     api_host: "{{ proxmox_api_host }}"
     ostemplate: "{{ lxc_config.container.ostemplate }}"
     disk: "{{ lxc_config.container.disk }}"
@@ -31,15 +44,15 @@
     netif: "{{ lxc_config.container.netif }}"
     onboot: "{{ lxc_config.container.onboot }}"
     unprivileged: "{{ lxc_config.container.unprivileged }}"
-    features: "{{ lxc_config.container.features | default('nesting=1,keyctl=1') }}"
+    features: "{{ lxc_config.container.features | default(omit, true) }}"
     state: present
 
 - name: Start container
   community.general.proxmox:
     vmid: "{{ lxc_config.container.vmid }}"
     node: "{{ proxmox_node }}"
-    api_user: "{{ proxmox_api_user }}"
-    api_password: "{{ proxmox_api_password }}"
+    api_token_id: "{{ proxmox_api_token_id }}"
+    api_token_secret: "{{ proxmox_api_token_secret }}"
     api_host: "{{ proxmox_api_host }}"
     state: started
 

--- a/roles/podman_host/defaults/main.yml
+++ b/roles/podman_host/defaults/main.yml
@@ -12,3 +12,10 @@ podman_host_firewalld_zone: trusted
 podman_host_cron_minute: 0
 podman_host_cron_hour: 2
 podman_host_prune_command: /usr/bin/podman system prune -f
+podman_host_policy_default:
+  - type: reject
+podman_host_policy_transports:
+  docker: {}
+  docker-daemon:
+    "":
+      - type: reject

--- a/roles/podman_host/templates/policy.json.j2
+++ b/roles/podman_host/templates/policy.json.j2
@@ -1,16 +1,12 @@
 {
-  "default": [
-    {
-      "type": "insecureAcceptAnything"
-    }
-  ],
+  "default": {{ podman_host_policy_default | to_json }},
   "transports": {
-    "docker-daemon": {
-      "": [
-        {
-          "type": "insecureAcceptAnything"
-        }
-      ]
-    }
+{% for transport, prefixes in podman_host_policy_transports | dictsort %}
+    "{{ transport }}": {
+{% for prefix, rules in prefixes | dictsort %}
+      "{{ prefix }}": {{ rules | to_json }}{% if not loop.last %},{% endif %}
+{% endfor %}
+    }{% if not loop.last %},{% endif %}
+{% endfor %}
   }
 }

--- a/roles/system_hardening/defaults/main.yml
+++ b/roles/system_hardening/defaults/main.yml
@@ -37,6 +37,8 @@ hardening_umask_targets:
 hardening_aide_db_path: /var/lib/aide/aide.db.gz
 hardening_aide_new_db_path: /var/lib/aide/aide.db.new.gz
 hardening_firewalld_zone: public
-hardening_firewalld_services:
-  - cockpit
+hardening_firewalld_services: []
 hardening_firewalld_ports: []
+hardening_enable_cockpit: false
+hardening_cockpit_listen_address: 127.0.0.1
+hardening_cockpit_allowed_sources: []

--- a/roles/system_hardening/handlers/main.yml
+++ b/roles/system_hardening/handlers/main.yml
@@ -7,3 +7,13 @@
 - name: Validate sudoers configuration
   ansible.builtin.command: visudo -cf /etc/sudoers
   changed_when: false
+
+- name: Reload systemd daemon
+  ansible.builtin.systemd:
+    daemon_reload: true
+
+- name: Restart cockpit socket
+  ansible.builtin.systemd:
+    name: cockpit.socket
+    state: restarted
+    enabled: true

--- a/roles/system_hardening/tasks/common.yml
+++ b/roles/system_hardening/tasks/common.yml
@@ -9,6 +9,20 @@
     state: present
   when: hardening_package_target | length > 0
 
+- name: Resolve cockpit package set for distribution
+  ansible.builtin.set_fact:
+    hardening_cockpit_package_target: "{{ hardening_cockpit_packages.get(ansible_distribution, hardening_cockpit_packages.get(ansible_os_family, [])) }}"
+  when: hardening_enable_cockpit
+
+- name: Ensure cockpit packages are installed when enabled
+  ansible.builtin.package:
+    name: "{{ hardening_cockpit_package_target }}"
+    state: present
+  when:
+    - hardening_enable_cockpit
+    - hardening_cockpit_package_target is defined
+    - hardening_cockpit_package_target | length > 0
+
 - name: Check for existing AIDE database
   ansible.builtin.stat:
     path: "{{ hardening_aide_db_path }}"
@@ -67,7 +81,7 @@
     mode: '0440'
   notify: Validate sudoers configuration
 
-- name: Configure sudo cockpit exception
+- name: Configure sudo cockpit exception when enabled
   ansible.builtin.copy:
     dest: /etc/sudoers.d/cockpit
     content: |-
@@ -76,6 +90,42 @@
     group: root
     mode: '0440'
   notify: Validate sudoers configuration
+  when: hardening_enable_cockpit
+
+- name: Remove sudo cockpit exception when disabled
+  ansible.builtin.file:
+    path: /etc/sudoers.d/cockpit
+    state: absent
+  notify: Validate sudoers configuration
+  when: not hardening_enable_cockpit
+
+- name: Ensure cockpit socket override directory exists when enabled
+  ansible.builtin.file:
+    path: /etc/systemd/system/cockpit.socket.d
+    state: directory
+    owner: root
+    group: root
+    mode: '0755'
+  when: hardening_enable_cockpit
+
+- name: Configure cockpit socket binding
+  ansible.builtin.template:
+    src: cockpit-listen.conf.j2
+    dest: /etc/systemd/system/cockpit.socket.d/listen.conf
+    owner: root
+    group: root
+    mode: '0644'
+  notify:
+    - Reload systemd daemon
+    - Restart cockpit socket
+  when: hardening_enable_cockpit
+
+- name: Remove cockpit socket override when disabled
+  ansible.builtin.file:
+    path: /etc/systemd/system/cockpit.socket.d/listen.conf
+    state: absent
+  notify: Reload systemd daemon
+  when: not hardening_enable_cockpit
 
 - name: Require TTY for sudo invocations
   ansible.builtin.copy:

--- a/roles/system_hardening/tasks/debian.yml
+++ b/roles/system_hardening/tasks/debian.yml
@@ -34,14 +34,21 @@
     - ufw default allow outgoing
   changed_when: false
 
-- name: Allow SSH and Cockpit in ufw
-  ansible.builtin.command: "ufw allow {{ item }}"
+- name: Allow SSH in ufw
+  ansible.builtin.command: "ufw allow {{ hardening_ssh_port }}/tcp"
   args:
     warn: false
-  loop:
-    - "{{ hardening_ssh_port }}/tcp"
-    - 9090/tcp
   changed_when: false
+
+- name: Allow cockpit management access in ufw
+  ansible.builtin.command: "ufw allow from {{ item }} to any port 9090 proto tcp"
+  args:
+    warn: false
+  loop: "{{ hardening_cockpit_allowed_sources }}"
+  changed_when: false
+  when:
+    - hardening_enable_cockpit
+    - hardening_cockpit_allowed_sources | length > 0
 
 - name: Enable ufw firewall
   ansible.builtin.command: ufw --force enable

--- a/roles/system_hardening/templates/cockpit-listen.conf.j2
+++ b/roles/system_hardening/templates/cockpit-listen.conf.j2
@@ -1,0 +1,3 @@
+[Socket]
+ListenStream=
+ListenStream={{ hardening_cockpit_listen_address }}:9090

--- a/roles/system_hardening/vars/main.yml
+++ b/roles/system_hardening/vars/main.yml
@@ -3,11 +3,6 @@ hardening_packages_common:
   Debian:
     - python3
     - openssh-server
-    - cockpit
-    - cockpit-networkmanager
-    - cockpit-packagekit
-    - cockpit-storaged
-    - cockpit-sosreport
     - unattended-upgrades
     - fail2ban
     - auditd
@@ -20,13 +15,6 @@ hardening_packages_common:
   Ubuntu:
     - python3
     - openssh-server
-    - cockpit
-    - cockpit-networkmanager
-    - cockpit-packagekit
-    - cockpit-storaged
-    - cockpit-pcp
-    - cockpit-sosreport
-    - cockpit-tuned
     - unattended-upgrades
     - fail2ban
     - auditd
@@ -39,11 +27,6 @@ hardening_packages_common:
   AlmaLinux:
     - python3
     - openssh-server
-    - cockpit
-    - cockpit-networkmanager
-    - cockpit-packagekit
-    - cockpit-storaged
-    - cockpit-sosreport
     - selinux-policy-targeted
     - policycoreutils-python-utils
     - dnf-automatic
@@ -64,3 +47,25 @@ hardening_fail2ban_log_path_map:
   Debian: /var/log/auth.log
   Ubuntu: /var/log/auth.log
   AlmaLinux: /var/log/secure
+
+hardening_cockpit_packages:
+  Debian:
+    - cockpit
+    - cockpit-networkmanager
+    - cockpit-packagekit
+    - cockpit-storaged
+    - cockpit-sosreport
+  Ubuntu:
+    - cockpit
+    - cockpit-networkmanager
+    - cockpit-packagekit
+    - cockpit-storaged
+    - cockpit-pcp
+    - cockpit-sosreport
+    - cockpit-tuned
+  AlmaLinux:
+    - cockpit
+    - cockpit-networkmanager
+    - cockpit-packagekit
+    - cockpit-storaged
+    - cockpit-sosreport

--- a/schemas/service.schema.yml
+++ b/schemas/service.schema.yml
@@ -173,7 +173,11 @@ properties:
       unprivileged:
         type: string
       features:
-        type: string
+        oneOf:
+          - type: string
+          - type: array
+            items:
+              type: string
   service_volume:
     type: object
   version:
@@ -219,6 +223,7 @@ properties:
     properties:
       shred_after_apply:
         type: boolean
+        default: true
       env:
         type: array
         items:

--- a/templates/proxmox.yml.j2
+++ b/templates/proxmox.yml.j2
@@ -4,6 +4,41 @@
 {% set file_list = service_files | default([]) %}
 {% set svc_list = service_services | default([]) %}
 {% set cmd_list = service_commands | default([]) %}
+{% set pkg_names = namespace(items=[]) %}
+{% for pkg in pkg_list %}
+  {% if pkg is string %}
+    {% set pkg_name = pkg %}
+  {% elif pkg.name is defined %}
+    {% set pkg_name = pkg.name %}
+  {% else %}
+    {% set pkg_name = '' %}
+  {% endif %}
+  {% if pkg_name %}
+    {% set _ = pkg_names.items.append(pkg_name | lower) %}
+  {% endif %}
+{% endfor %}
+{% set feature_ns = namespace(value=None) %}
+{% if container.features is defined %}
+  {% if container.features %}
+    {% if container.features is string %}
+      {% set feature_ns.value = container.features %}
+    {% elif container.features is sequence %}
+      {% set feature_ns.value = container.features | join(',') %}
+    {% else %}
+      {% set feature_ns.value = container.features | string %}
+    {% endif %}
+  {% else %}
+    {% set feature_ns.value = '' %}
+  {% endif %}
+{% endif %}
+{% if feature_ns.value is none %}
+  {% set nested_indicators = ['docker', 'docker-ce', 'docker.io', 'podman', 'podman-docker', 'containerd', 'buildah'] %}
+  {% for indicator in nested_indicators %}
+    {% if indicator in pkg_names.items %}
+      {% set feature_ns.value = 'nesting=1,keyctl=1' %}
+    {% endif %}
+  {% endfor %}
+{% endif %}
 container_ip: "{{ service_ip }}"
 container:
   vmid: "{{ container.vmid | default(service_id) }}"
@@ -17,7 +52,9 @@ container:
     net0: "name={{ container.interface | default('eth0') }},bridge={{ container.bridge | default('vmbr0') }},ip={{ service_ip }}/{{ container.cidr | default(24) }}{% if container.gateway is defined %},gw={{ container.gateway }}{% elif service_gateway is defined %},gw={{ service_gateway }}{% endif %}"
   onboot: {{ container.onboot | default('yes') }}
   unprivileged: {{ container.unprivileged | default('yes') }}
-  features: "{{ container.features | default('nesting=1,keyctl=1') }}"
+{% if feature_ns.value %}
+  features: "{{ feature_ns.value }}"
+{% endif %}
 
 setup:
   packages:{% if pkg_list | length == 0 %} []{% else %}


### PR DESCRIPTION
## Summary
- default secret shredding to true across Compose/Quadlet and document the opt-out path
- lock Podman image policy to per-transport allow lists with a reject-by-default baseline
- make Cockpit installation optional, binding the socket locally unless explicit addresses are supplied, and switch Proxmox auth to API tokens with computed LXC features

## Testing
- ansible-playbook tests/render.yml -e @tests/sample_service.yml -e runtime=podman -e '{"runtime_templates": {"podman": "../templates/podman.yml.j2"}}'
- ansible-playbook tests/render.yml -e @tests/sample_service.yml -e runtime=docker -e '{"runtime_templates": {"docker": "../templates/docker.yml.j2"}}'
- ansible-playbook tests/render.yml -e @tests/sample_service.yml -e runtime=proxmox -e '{"runtime_templates": {"proxmox": "../templates/proxmox.yml.j2"}}'
- ansible-playbook tests/render.yml -e @tests/sample_service.yml -e runtime=baremetal -e '{"runtime_templates": {"baremetal": "../templates/baremetal.yml.j2"}}'
- ansible-playbook tests/render.yml -e @tests/sample_service.yml -e runtime=kubernetes -e '{"runtime_templates": {"kubernetes": "../templates/kubernetes.yml.j2"}}'

------
https://chatgpt.com/codex/tasks/task_e_68f3db238624832eba60e8181104ac84