### PR TITLE
Harden runtime defaults and CI validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,21 +13,28 @@ jobs:
       fail-fast: false
       matrix:
         lane: [stable, latest]
+        include:
+          - lane: stable
+            kubectl_version: v1.29.3
+            kind_image: kindest/node:v1.29.3
+          - lane: latest
+            kubectl_version: v1.30.0
+            kind_image: kindest/node:v1.30.0
     env:
       SAMPLE_SERVICE_ID: sample-service
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@9bb561d33b5b7c63f00a615b73d2be5c648ebc62
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@13f5f90d8d8c77c1b39979f68de0b44b4540a0ec
         with:
           python-version: '3.11'
 
       - name: Install Python dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install ansible ansible-lint yamllint jsonschema pyyaml
+          pip install -r ci/requirements.txt
 
       - name: Install Ansible collections
         run: ansible-galaxy collection install -r ci/collections-${{ matrix.lane }}.yml
@@ -35,17 +42,26 @@ jobs:
       - name: Verify Docker Compose availability
         run: docker compose version
 
-      - name: Set up kubectl (stable)
-        if: matrix.lane == 'stable'
-        uses: azure/setup-kubectl@v3
-        with:
-          version: 'v1.29.3'
+      - name: Install kubectl
+        env:
+          KUBECTL_VERSION: ${{ matrix.kubectl_version }}
+        run: |
+          curl -Lo kubectl "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl"
+          curl -Lo kubectl.sha256 "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl.sha256"
+          echo "$(cat kubectl.sha256)  kubectl" | sha256sum --check -
+          chmod +x kubectl
+          sudo mv kubectl /usr/local/bin/kubectl
 
-      - name: Set up kubectl (latest)
-        if: matrix.lane == 'latest'
-        uses: azure/setup-kubectl@v3
-        with:
-          version: 'latest'
+      - name: Install kind
+        env:
+          KIND_VERSION: v0.23.0
+        run: |
+          curl -Lo kind "https://github.com/kubernetes-sigs/kind/releases/download/${KIND_VERSION}/kind-linux-amd64"
+          curl -Lo kind.sha256sum "https://github.com/kubernetes-sigs/kind/releases/download/${KIND_VERSION}/kind-linux-amd64.sha256sum"
+          grep "kind-linux-amd64" kind.sha256sum > kind-linux-amd64.sha256
+          sha256sum --check kind-linux-amd64.sha256
+          chmod +x kind
+          sudo mv kind /usr/local/bin/kind
 
       - name: Validate schema definition
         run: python ci/validate_schema.py
@@ -84,5 +100,15 @@ jobs:
       - name: Render Kubernetes manifests
         run: ansible-playbook tests/render.yml -e runtime=kubernetes
 
-      - name: Validate Kubernetes manifest
+      - name: Create kind cluster for validation
+        run: kind create cluster --name ci-${{ matrix.lane }} --image ${{ matrix.kind_image }} --wait 120s
+
+      - name: Validate Kubernetes manifest (client)
         run: kubectl apply --dry-run=client --validate=true -f /tmp/ansible-runtime/${{ env.SAMPLE_SERVICE_ID }}/kubernetes.yml
+
+      - name: Validate Kubernetes manifest (server)
+        run: kubectl apply --dry-run=server --validate=true -f /tmp/ansible-runtime/${{ env.SAMPLE_SERVICE_ID }}/kubernetes.yml
+
+      - name: Delete kind cluster
+        if: always()
+        run: kind delete cluster --name ci-${{ matrix.lane }} || true

--- a/ci/requirements.txt
+++ b/ci/requirements.txt
@@ -1,0 +1,5 @@
+ansible==9.5.1
+ansible-lint==24.6.1
+yamllint==1.35.1
+jsonschema==4.22.0
+PyYAML==6.0.1

--- a/docs/baremetal.md
+++ b/docs/baremetal.md
@@ -28,8 +28,8 @@ ansible-galaxy collection install community.general
 ## Variables
 
 - `service_unit` – override description, dependencies, or the `[Service]` stanza for advanced workloads.
-- `service_packages` – list of packages to install before enabling the unit.
-- `secrets.shred_after_apply` – available to keep secret files ephemeral when combined with runtime adapters that create them locally.
+- `service_packages` – list of packages (optionally pinned with `version`) to install before enabling the unit.
+- `secrets.shred_after_apply` – defaults to `true` to keep rendered secrets ephemeral; disable only for debugging.
 
 ## Validation
 

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -31,7 +31,7 @@ version: '3.8'
 
 services:
   sample-service:
-    image: docker.io/library/nginx:1.27
+    image: docker.io/library/nginx@sha256:4cdc4c8f840c98c47404108002c658d2d44df83228c166a4630bf4161eee7bc6
     container_name: sample-service
     restart: unless-stopped
     env_file:
@@ -72,7 +72,7 @@ networks:
 
 - `secrets.env` entries feed the env file.
 - `secrets.files` entries create files in `secrets/<name>` and populate the Compose `secrets` map.
-- `secrets.shred_after_apply` removes rendered secrets after deployment when set to `true`.
+- `secrets.shred_after_apply` defaults to `true` so rendered secrets are wiped after deployment; disable only for debugging.
 - `service_ports` control host bindings; publish only the ports you intend to expose.
 
 ## Validating the render
@@ -89,7 +89,7 @@ docker compose -f /tmp/ansible-runtime/sample-service/docker.yml config
 
 1. Builds the env file and optional `secrets/` directory under the render output.
 2. Invokes `community.docker.docker_compose_v2` with `pull: always` to keep images fresh.
-3. Optionally shreds rendered secrets when `secrets.shred_after_apply` is enabled.
+3. Shreds rendered secrets when `secrets.shred_after_apply` remains at the secure default.
 4. Sets `service_ip` for the unified health gate.
 
 Use the shared health command to run a post-deploy verification:

--- a/docs/podman.md
+++ b/docs/podman.md
@@ -7,6 +7,7 @@ Deploy services using Podman Quadlets with environment files, optional user scop
 - `quadlet_scope` selects system-wide (`/etc/containers/systemd`) or per-user (`~/.config/containers/systemd`) installation.
 - Secrets from the contract populate an environment file and optional `secrets/` directory, mounted read-only into the container.
 - Health checks map directly to `HealthCmd/HealthInterval/HealthTimeout/HealthRetries` derived from `health.cmd`.
+- `/etc/containers/policy.json` defaults to rejecting unsigned images. Override `podman_host_policy` to allow trusted registries (prefer `signedBy` over `insecureAcceptAnything`).
 
 ## Requirements
 
@@ -32,9 +33,8 @@ After=network-online.target
 Wants=network-online.target
 
 [Container]
-Image=docker.io/library/nginx:1.27
+Image=docker.io/library/nginx@sha256:4cdc4c8f840c98c47404108002c658d2d44df83228c166a4630bf4161eee7bc6
 ContainerName=sample-service
-AutoUpdate=registry
 Environment=APP_MODE=production
 Environment=APP_FEATURE_FLAG=true
 EnvironmentFile=/etc/containers/systemd/sample-service.env
@@ -62,9 +62,9 @@ For `quadlet_scope: user`, the environment file and secrets live under `~/.confi
 
 1. Computes the target directories based on `quadlet_scope`.
 2. Writes the env file and optional secret files (with `0400` default permissions).
-3. Copies the `.container` unit.
+3. Copies the `.container` unit (enable auto-updates explicitly with `service_autoupdate: true`).
 4. Executes `systemd` tasks with the correct scope and reloads daemons.
-5. Optionally shreds rendered secrets when `secrets.shred_after_apply` is enabled.
+5. Shreds rendered secrets when `secrets.shred_after_apply` is left at the default `true`.
 6. Sets `service_ip` for the post-deploy health gate.
 
 Ensure lingering is enabled when deploying user-scoped units:

--- a/docs/proxmox.md
+++ b/docs/proxmox.md
@@ -5,15 +5,16 @@ Deploy services as LXC containers on Proxmox VE with predictable networking and 
 ## Key changes
 
 - Templates emit `container_ip`, removing brittle IP parsing in Ansible tasks.
-- LXC containers declare `features: nesting=1,keyctl=1` so Docker/Podman workloads function inside the guest when required.
 - Ansible waits for SSH on `container_ip` (120 seconds) before running delegate tasks.
-- Package installation inside the container uses non-interactive APT and applies any rendered configuration or command hooks.
+- Package installation inside the container uses non-interactive APT with per-package pinning and applies any rendered configuration or command hooks.
+- API access now uses scoped Proxmox API tokens (`proxmox_api_token_id`/`proxmox_api_token_secret`) instead of passwords.
 
 ## Prerequisites
 
 ### Proxmox VE
 
 - Proxmox VE 7.0 or newer with API access.
+- Scoped API token (`user@realm!tokenid`) with only the permissions required for LXC lifecycle operations.
 - Ubuntu 24.04 container template (defaults to `local:vztmpl/ubuntu-24.04-standard_24.04-2_amd64.tar.zst`).
 - Network bridge with reachable gateway.
 
@@ -44,11 +45,10 @@ container:
     net0: "name=eth0,bridge=vmbr0,ip=192.0.2.50/24,gw=192.0.2.1"
   onboot: yes
   unprivileged: yes
-  features: "nesting=1,keyctl=1"
-
 setup:
   packages:
-    - nginx
+    - name: nginx
+      version: 1.24.0-2ubuntu1
   config:
     - path: /etc/sample-service/runtime.env
       content: |
@@ -65,7 +65,7 @@ setup:
 
 1. Render the template (see `tests/render.yml`).
 2. `roles/common/apply_runtime/tasks/proxmox.yml`:
-   - Creates or updates the container with the declared features.
+   - Creates or updates the container with any explicitly declared features.
    - Waits for SSH on `container_ip:22`.
    - Installs packages via non-interactive APT when requested.
    - Copies configuration files and enables systemd services declared in `setup.services`.
@@ -75,9 +75,9 @@ setup:
 
 - Explicit IP assignments keep host firewalls predictable.
 - Use Proxmox firewall rules or host-level filtering for exposed ports.
-- Keep `features` minimal; remove `nesting` when containerized workloads are not required.
+- Keep `features` minimal; the template no longer enables `nesting`/`keyctl` unless you request them.
 
 ## Troubleshooting
 
 - **Delegation errors** – confirm `container_ip` resolves and SSH is reachable. Increase the `wait_for` timeout for large templates.
-- **Package installation failures** – ensure the container has outbound network access and `DEBIAN_FRONTEND=noninteractive` is accepted.
+- **Package installation failures** – ensure the container has outbound network access, `DEBIAN_FRONTEND=noninteractive` is accepted, and declared versions exist in your repositories.

--- a/roles/common/apply_runtime/tasks/docker.yml
+++ b/roles/common/apply_runtime/tasks/docker.yml
@@ -4,7 +4,7 @@
     compose_secret_env: "{{ secrets.env if secrets is defined and secrets.env is not none and secrets.env | length > 0 else [] }}"
     compose_secret_files: "{{ secrets.files if secrets is defined and secrets.files is not none and secrets.files | length > 0 else [] }}"
     compose_secret_env_path: "{{ runtime_output_dir }}/{{ service_name | default(service_id) }}.env"
-    compose_secret_shred: "{{ secrets.shred_after_apply | default(false) if secrets is defined else false }}"
+    compose_secret_shred: "{{ secrets.shred_after_apply | default(true) if secrets is defined else false }}"
 
 - name: Write Compose secret environment file
   copy:

--- a/roles/common/apply_runtime/tasks/podman.yml
+++ b/roles/common/apply_runtime/tasks/podman.yml
@@ -14,7 +14,7 @@
   set_fact:
     quadlet_secret_env: "{{ secrets.env if secrets is defined and secrets.env is not none and secrets.env | length > 0 else [] }}"
     quadlet_secret_files: "{{ secrets.files if secrets is defined and secrets.files is not none and secrets.files | length > 0 else [] }}"
-    quadlet_secret_shred: "{{ secrets.shred_after_apply | default(false) if secrets is defined else false }}"
+    quadlet_secret_shred: "{{ secrets.shred_after_apply | default(true) if secrets is defined else false }}"
 
 - name: Deduplicate quadlet secret environment variables
   set_fact:

--- a/roles/common/apply_runtime/tasks/proxmox.yml
+++ b/roles/common/apply_runtime/tasks/proxmox.yml
@@ -3,6 +3,14 @@
   set_fact:
     lxc_config: "{{ lookup('file', runtime_config_path) | from_yaml }}"
 
+- name: Ensure Proxmox API token credentials are provided
+  assert:
+    that:
+      - proxmox_api_user is defined
+      - proxmox_api_token_id is defined
+      - proxmox_api_token_secret is defined
+    fail_msg: "Proxmox runtime requires proxmox_api_user, proxmox_api_token_id, and proxmox_api_token_secret"
+
 - name: Ensure container_ip is defined
   assert:
     that:
@@ -21,7 +29,8 @@
     hostname: "{{ lxc_config.container.hostname }}"
     node: "{{ proxmox_node }}"
     api_user: "{{ proxmox_api_user }}"
-    api_password: "{{ proxmox_api_password }}"
+    api_token_id: "{{ proxmox_api_token_id }}"
+    api_token_secret: "{{ proxmox_api_token_secret }}"
     api_host: "{{ proxmox_api_host }}"
     ostemplate: "{{ lxc_config.container.ostemplate }}"
     disk: "{{ lxc_config.container.disk }}"
@@ -31,7 +40,7 @@
     netif: "{{ lxc_config.container.netif }}"
     onboot: "{{ lxc_config.container.onboot }}"
     unprivileged: "{{ lxc_config.container.unprivileged }}"
-    features: "{{ lxc_config.container.features | default('nesting=1,keyctl=1') }}"
+    features: {{ lxc_config.container.features | default(omit) }}
     state: present
 
 - name: Start container
@@ -39,7 +48,8 @@
     vmid: "{{ lxc_config.container.vmid }}"
     node: "{{ proxmox_node }}"
     api_user: "{{ proxmox_api_user }}"
-    api_password: "{{ proxmox_api_password }}"
+    api_token_id: "{{ proxmox_api_token_id }}"
+    api_token_secret: "{{ proxmox_api_token_secret }}"
     api_host: "{{ proxmox_api_host }}"
     state: started
 
@@ -49,13 +59,24 @@
     port: 22
     timeout: 120
 
-- name: Install packages in container
+- name: Update package cache in container when packages are requested
   delegate_to: "{{ container_ip }}"
   become: true
   apt:
-    name: "{{ lxc_config.setup.packages | default([]) }}"
-    state: present
     update_cache: yes
+  environment:
+    DEBIAN_FRONTEND: noninteractive
+  when: lxc_config.setup.packages is defined and lxc_config.setup.packages | length > 0
+
+- name: Install pinned packages in container
+  delegate_to: "{{ container_ip }}"
+  become: true
+  apt:
+    name: "{{ (item.name if item is mapping else item) ~ (('=' ~ item.version) if item is mapping and item.version is defined else '') }}"
+    state: "{{ item.state | default('present') if item is mapping else 'present' }}"
+  loop: "{{ lxc_config.setup.packages | default([]) }}"
+  loop_control:
+    label: "{{ item.name if item is mapping else item }}"
   environment:
     DEBIAN_FRONTEND: noninteractive
   when: lxc_config.setup.packages is defined and lxc_config.setup.packages | length > 0

--- a/roles/podman_host/defaults/main.yml
+++ b/roles/podman_host/defaults/main.yml
@@ -12,3 +12,10 @@ podman_host_firewalld_zone: trusted
 podman_host_cron_minute: 0
 podman_host_cron_hour: 2
 podman_host_prune_command: /usr/bin/podman system prune -f
+podman_host_policy:
+  default:
+    - type: reject
+  transports:
+    docker-daemon:
+      "":
+        - type: reject

--- a/roles/podman_host/templates/policy.json.j2
+++ b/roles/podman_host/templates/policy.json.j2
@@ -1,16 +1,1 @@
-{
-  "default": [
-    {
-      "type": "insecureAcceptAnything"
-    }
-  ],
-  "transports": {
-    "docker-daemon": {
-      "": [
-        {
-          "type": "insecureAcceptAnything"
-        }
-      ]
-    }
-  }
-}
+{{ podman_host_policy | to_nice_json }}

--- a/roles/system_hardening/defaults/main.yml
+++ b/roles/system_hardening/defaults/main.yml
@@ -4,7 +4,7 @@ hardening_authorized_users: []  # list of {name: user, key: ssh-rsa ...}
 hardening_fail2ban_maxretry: 3
 hardening_fail2ban_bantime: 3600
 hardening_fail2ban_findtime: 600
-hardening_enable_ipv6: false
+hardening_enable_ipv6: true
 hardening_weekly_aide_check_minute: 0
 hardening_weekly_aide_check_hour: 3
 hardening_weekly_aide_check_day: 1
@@ -37,6 +37,7 @@ hardening_umask_targets:
 hardening_aide_db_path: /var/lib/aide/aide.db.gz
 hardening_aide_new_db_path: /var/lib/aide/aide.db.new.gz
 hardening_firewalld_zone: public
-hardening_firewalld_services:
-  - cockpit
+hardening_firewalld_services: []
 hardening_firewalld_ports: []
+hardening_enable_cockpit: false
+hardening_cockpit_bind_address: 127.0.0.1

--- a/roles/system_hardening/handlers/main.yml
+++ b/roles/system_hardening/handlers/main.yml
@@ -7,3 +7,10 @@
 - name: Validate sudoers configuration
   ansible.builtin.command: visudo -cf /etc/sudoers
   changed_when: false
+
+- name: Reload cockpit socket
+  ansible.builtin.systemd:
+    name: cockpit.socket
+    state: restarted
+    daemon_reload: true
+  failed_when: false

--- a/roles/system_hardening/tasks/common.yml
+++ b/roles/system_hardening/tasks/common.yml
@@ -3,6 +3,15 @@
   ansible.builtin.set_fact:
     hardening_package_target: "{{ hardening_packages_common.get(ansible_distribution, hardening_packages_common.get(ansible_os_family, [])) }}"
 
+- name: Extend package set for Cockpit when enabled
+  ansible.builtin.set_fact:
+    hardening_package_target: "{{ (hardening_package_target + cockpit_packages) | unique }}"
+  vars:
+    cockpit_packages: "{{ hardening_cockpit_packages_map.get(ansible_distribution, hardening_cockpit_packages_map.get(ansible_os_family, [])) }}"
+  when:
+    - hardening_enable_cockpit | bool
+    - cockpit_packages | length > 0
+
 - name: Ensure base hardening packages are installed
   ansible.builtin.package:
     name: "{{ hardening_package_target }}"
@@ -67,16 +76,6 @@
     mode: '0440'
   notify: Validate sudoers configuration
 
-- name: Configure sudo cockpit exception
-  ansible.builtin.copy:
-    dest: /etc/sudoers.d/cockpit
-    content: |-
-      Defaults:cockpit !authenticate
-    owner: root
-    group: root
-    mode: '0440'
-  notify: Validate sudoers configuration
-
 - name: Require TTY for sudo invocations
   ansible.builtin.copy:
     dest: /etc/sudoers.d/requiretty
@@ -121,3 +120,37 @@
     state: stopped
   loop: "{{ (hardening_disable_services + hardening_additional_disable_services) | unique }}"
   ignore_errors: true
+
+- name: Ensure Cockpit socket is disabled when Cockpit is not enabled
+  ansible.builtin.systemd:
+    name: cockpit.socket
+    enabled: false
+    state: stopped
+    daemon_reload: true
+  when: not hardening_enable_cockpit
+  failed_when: false
+  ignore_errors: true
+
+- name: Remove Cockpit socket overrides when Cockpit is disabled
+  ansible.builtin.file:
+    path: /etc/systemd/system/cockpit.socket.d
+    state: absent
+  when: not hardening_enable_cockpit
+
+- name: Ensure Cockpit socket override directory exists when enabled
+  ansible.builtin.file:
+    path: /etc/systemd/system/cockpit.socket.d
+    state: directory
+    mode: '0755'
+  when: hardening_enable_cockpit
+
+- name: Configure Cockpit bind address override
+  ansible.builtin.copy:
+    dest: /etc/systemd/system/cockpit.socket.d/listen.conf
+    mode: '0644'
+    content: |-
+      [Socket]
+      ListenStream=
+      ListenStream={{ hardening_cockpit_bind_address }}:9090
+  when: hardening_enable_cockpit
+  notify: Reload cockpit socket

--- a/roles/system_hardening/tasks/debian.yml
+++ b/roles/system_hardening/tasks/debian.yml
@@ -34,13 +34,12 @@
     - ufw default allow outgoing
   changed_when: false
 
-- name: Allow SSH and Cockpit in ufw
+- name: Allow SSH in ufw
   ansible.builtin.command: "ufw allow {{ item }}"
   args:
     warn: false
   loop:
     - "{{ hardening_ssh_port }}/tcp"
-    - 9090/tcp
   changed_when: false
 
 - name: Enable ufw firewall

--- a/roles/system_hardening/vars/main.yml
+++ b/roles/system_hardening/vars/main.yml
@@ -3,11 +3,6 @@ hardening_packages_common:
   Debian:
     - python3
     - openssh-server
-    - cockpit
-    - cockpit-networkmanager
-    - cockpit-packagekit
-    - cockpit-storaged
-    - cockpit-sosreport
     - unattended-upgrades
     - fail2ban
     - auditd
@@ -20,13 +15,6 @@ hardening_packages_common:
   Ubuntu:
     - python3
     - openssh-server
-    - cockpit
-    - cockpit-networkmanager
-    - cockpit-packagekit
-    - cockpit-storaged
-    - cockpit-pcp
-    - cockpit-sosreport
-    - cockpit-tuned
     - unattended-upgrades
     - fail2ban
     - auditd
@@ -39,11 +27,6 @@ hardening_packages_common:
   AlmaLinux:
     - python3
     - openssh-server
-    - cockpit
-    - cockpit-networkmanager
-    - cockpit-packagekit
-    - cockpit-storaged
-    - cockpit-sosreport
     - selinux-policy-targeted
     - policycoreutils-python-utils
     - dnf-automatic
@@ -64,3 +47,24 @@ hardening_fail2ban_log_path_map:
   Debian: /var/log/auth.log
   Ubuntu: /var/log/auth.log
   AlmaLinux: /var/log/secure
+hardening_cockpit_packages_map:
+  Debian:
+    - cockpit
+    - cockpit-networkmanager
+    - cockpit-packagekit
+    - cockpit-storaged
+    - cockpit-sosreport
+  Ubuntu:
+    - cockpit
+    - cockpit-networkmanager
+    - cockpit-packagekit
+    - cockpit-storaged
+    - cockpit-pcp
+    - cockpit-sosreport
+    - cockpit-tuned
+  AlmaLinux:
+    - cockpit
+    - cockpit-networkmanager
+    - cockpit-packagekit
+    - cockpit-storaged
+    - cockpit-sosreport

--- a/schemas/service.schema.yml
+++ b/schemas/service.schema.yml
@@ -17,6 +17,7 @@ properties:
     type: string
   service_image:
     type: string
+    pattern: ".+@sha256:[0-9a-f]{64}$"
   service_ip:
     type: string
   service_port:
@@ -97,7 +98,17 @@ properties:
   service_packages:
     type: array
     items:
-      type: string
+      oneOf:
+        - type: string
+        - type: object
+          required: [name]
+          properties:
+            name:
+              type: string
+            version:
+              type: string
+            state:
+              type: string
   service_files:
     type: array
     items:
@@ -219,6 +230,7 @@ properties:
     properties:
       shred_after_apply:
         type: boolean
+        default: true
       env:
         type: array
         items:

--- a/templates/kubernetes.yml.j2
+++ b/templates/kubernetes.yml.j2
@@ -2,7 +2,8 @@
 {% set namespace = service_namespace | default('default') %}
 {% set secret_env = secrets.env if secrets is defined and secrets.env is not none and secrets.env | length > 0 else [] %}
 {% set file_secrets = secrets.files if secrets is defined and secrets.files is not none and secrets.files | length > 0 else [] %}
-{% set secret_name = svc_name + '-secrets' %}
+{% set env_secret_name = svc_name + '-env' %}
+{% set file_secret_name = svc_name + '-files' %}
 {% set health_cmd = health.cmd | default(['true']) %}
 {% set health_interval_seconds = (health.interval | default('10s')) | regex_replace('s$', '') | int %}
 {% set health_timeout_seconds = (health.timeout | default('5s')) | regex_replace('s$', '') | int %}
@@ -25,20 +26,32 @@
 {% set storage_size = '1Gi' %}
 {% endif %}
 {% set volume_mount_path = volume_config.target if volume_config is mapping and volume_config.target is defined else '/data' %}
+{% if secret_env %}
 ---
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ secret_name }}
+  name: {{ env_secret_name }}
   namespace: {{ namespace }}
 type: Opaque
 stringData:
 {% for item in secret_env %}
   {{ item.name }}: {{ item.value | to_json }}
 {% endfor %}
+{% endif %}
+{% if file_secrets %}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ file_secret_name }}
+  namespace: {{ namespace }}
+type: Opaque
+stringData:
 {% for secret in file_secrets %}
   {{ secret.name }}: {{ (secret.value | default(secret.content) | default('', true)) | to_json }}
 {% endfor %}
+{% endif %}
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim
@@ -75,7 +88,7 @@ spec:
             - name: {{ item.name }}
               valueFrom:
                 secretKeyRef:
-                  name: {{ secret_name }}
+                  name: {{ env_secret_name }}
                   key: {{ item.name }}
 {% endfor %}
 {% for item in service_env | default([]) %}
@@ -130,7 +143,7 @@ spec:
 {% if file_secrets %}
         - name: secret-files
           secret:
-            secretName: {{ secret_name }}
+            secretName: {{ file_secret_name }}
             items:
 {% for secret in file_secrets %}
               - key: {{ secret.name }}

--- a/templates/podman.yml.j2
+++ b/templates/podman.yml.j2
@@ -11,6 +11,8 @@
 {% set ports = service_ports | default((service_port is defined) | ternary([service_port], [])) %}
 {% set volumes = service_volumes | default([]) %}
 {% set inline_env = service_env | default([]) %}
+{% set autoupdate_enabled = service_autoupdate | default(false) %}
+{% set autoupdate_mode = service_autoupdate_mode | default('registry') %}
 [Unit]
 Description={{ service_unit_description | default('Managed container for ' ~ (service_name | default(service_id))) }}
 After=network-online.target
@@ -19,7 +21,9 @@ Wants=network-online.target
 [Container]
 Image={{ service_image }}
 ContainerName={{ service_name | default(service_id) }}
-AutoUpdate=registry
+{% if autoupdate_enabled %}
+AutoUpdate={{ autoupdate_mode }}
+{% endif %}
 {% for env in inline_env %}
 Environment={{ env.name }}={{ env.value }}
 {% endfor %}

--- a/templates/proxmox.yml.j2
+++ b/templates/proxmox.yml.j2
@@ -4,6 +4,7 @@
 {% set file_list = service_files | default([]) %}
 {% set svc_list = service_services | default([]) %}
 {% set cmd_list = service_commands | default([]) %}
+{% set container_features = container.features | default('') %}
 container_ip: "{{ service_ip }}"
 container:
   vmid: "{{ container.vmid | default(service_id) }}"
@@ -17,12 +18,16 @@ container:
     net0: "name={{ container.interface | default('eth0') }},bridge={{ container.bridge | default('vmbr0') }},ip={{ service_ip }}/{{ container.cidr | default(24) }}{% if container.gateway is defined %},gw={{ container.gateway }}{% elif service_gateway is defined %},gw={{ service_gateway }}{% endif %}"
   onboot: {{ container.onboot | default('yes') }}
   unprivileged: {{ container.unprivileged | default('yes') }}
-  features: "{{ container.features | default('nesting=1,keyctl=1') }}"
+{% if container_features | string | length > 0 %}
+  features: "{{ container_features }}"
+{% endif %}
 
 setup:
   packages:{% if pkg_list | length == 0 %} []{% else %}
 {% for pkg in pkg_list %}
-    - {{ pkg }}
+    - name: {{ (pkg.name if pkg is mapping else pkg) }}{% if pkg is mapping and pkg.version is defined %}
+      version: {{ pkg.version }}{% endif %}{% if pkg is mapping and pkg.state is defined %}
+      state: {{ pkg.state }}{% endif %}
 {% endfor %}{% endif %}
   config:{% if file_list | length == 0 %} []{% else %}
 {% for item in file_list %}

--- a/tests/sample_service.yml
+++ b/tests/sample_service.yml
@@ -1,8 +1,8 @@
 service_id: sample-service
 service_name: sample-service
 service_unit_name: sample-service
-service_image: docker.io/library/nginx:1.27
-version: "1.27"
+service_image: docker.io/library/nginx@sha256:4cdc4c8f840c98c47404108002c658d2d44df83228c166a4630bf4161eee7bc6
+version: "1.27.0"
 service_ip: 192.0.2.50
 service_ports:
   - target: 8080
@@ -19,7 +19,8 @@ service_volumes:
     target: /etc/sample-service
     driver: local
 service_packages:
-  - nginx
+  - name: nginx
+    version: 1.24.0-2ubuntu1
 service_files:
   - path: /etc/sample-service/runtime.env
     mode: '0640'
@@ -53,7 +54,6 @@ service_container:
   interface: eth0
   onboot: yes
   unprivileged: yes
-  features: nesting=1,keyctl=1
 exports:
   env:
     - name: SAMPLE_SERVICE_URL
@@ -79,7 +79,7 @@ runtime_templates:
   kubernetes: templates/kubernetes.yml.j2
   baremetal: templates/baremetal.yml.j2
 secrets:
-  shred_after_apply: false
+  shred_after_apply: true
   env:
     - name: SAMPLE_SERVICE_TOKEN
       value: super-secret-token


### PR DESCRIPTION
## Summary
- reject unsigned images by default for Podman hosts and expose Quadlet auto-updates only when explicitly requested
- tighten system hardening defaults by keeping IPv6 enabled, removing Cockpit sudo/firewall exceptions, and scoping Cockpit access
- require digest-pinned images, split Kubernetes secrets, and modernize the Proxmox/Kubernetes pipelines with token auth, package pinning, and server-side validation in CI

## Testing
- pip install -r ci/requirements.txt *(fails: network restrictions prevent downloading pinned dependencies)*
- python ci/validate_schema.py *(fails: missing jsonschema because dependencies could not be installed offline)*

------
https://chatgpt.com/codex/tasks/task_e_68f3db8c10fc832ea8d800aade63fc1c