### PR TITLE
Add ingress modeling schema and role

### DIFF
--- a/roles/ingress_model/defaults/main.yml
+++ b/roles/ingress_model/defaults/main.yml
@@ -1,0 +1,4 @@
+---
+ingress_schema_path: "{{ role_path | path_join('../../schemas/ingress.schema.yml') }}"
+ingress_managed_by: acme.runtime
+ingress_owner: null

--- a/roles/ingress_model/library/ingress_model.py
+++ b/roles/ingress_model/library/ingress_model.py
@@ -1,0 +1,262 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+from typing import Any, Dict, List
+
+import yaml
+from ansible.module_utils.basic import AnsibleModule
+from jsonschema import Draft202012Validator
+
+
+def load_schema(schema_path: Path) -> dict:
+    try:
+        return yaml.safe_load(schema_path.read_text(encoding="utf-8"))
+    except FileNotFoundError as exc:
+        raise ValueError(f"Ingress schema not found at {schema_path}") from exc
+    except yaml.YAMLError as exc:
+        raise ValueError(
+            f"Invalid ingress schema YAML at {schema_path}: {exc}"
+        ) from exc
+
+
+def normalize_health(health: dict | None) -> dict:
+    base = {
+        "path": "/",
+        "interval": "30s",
+        "timeout": "5s",
+    }
+    if not health:
+        return base
+
+    normalized = base.copy()
+    for key in ("path", "interval", "timeout", "method", "expected_status"):
+        if key in health and health[key] is not None:
+            normalized[key] = health[key]
+    return normalized
+
+
+def normalize_tls(tls: dict | None) -> dict:
+    base = {
+        "mode": "auto",
+        "hsts": True,
+        "alpn": ["h2", "http/1.1"],
+        "redirect_http_to_https": True,
+    }
+    if tls is None:
+        return base
+
+    normalized = base.copy()
+
+    for key in ("mode", "hsts", "alpn", "redirect_http_to_https"):
+        if key in tls and tls[key] is not None:
+            normalized[key] = tls[key]
+
+    acme_defaults = {
+        "challenge": "dns",
+        "wildcard": False,
+    }
+    acme = tls.get("acme")
+    if acme is not None:
+        acme_normalized = acme_defaults.copy()
+        for key, value in acme.items():
+            if value is not None:
+                acme_normalized[key] = value
+        normalized["acme"] = acme_normalized
+
+    for optional in ("certificate_secret", "key_secret", "chain_secret"):
+        if optional in tls and tls[optional] is not None:
+            normalized[optional] = tls[optional]
+
+    return normalized
+
+
+def normalize_headers(headers: dict | None) -> dict:
+    if not headers:
+        return {"set": [], "remove": []}
+
+    normalized = {
+        "set": headers.get("set", []) or [],
+        "remove": headers.get("remove", []) or [],
+    }
+    return normalized
+
+
+def normalize_rate_limit(rate_limit: dict | None) -> dict:
+    if not rate_limit:
+        return {}
+
+    normalized: dict[str, Any] = {}
+    if (
+        "requests_per_minute" in rate_limit
+        and rate_limit["requests_per_minute"] is not None
+    ):
+        normalized["requests_per_minute"] = rate_limit["requests_per_minute"]
+    if "burst" in rate_limit and rate_limit["burst"] is not None:
+        normalized["burst"] = rate_limit["burst"]
+    return normalized
+
+
+def normalize_route(route: dict) -> dict:
+    normalized = {
+        "host": route["host"],
+        "port": route["port"],
+        "path_prefix": route.get("path_prefix", "/") or "/",
+        "websocket": bool(route.get("websocket", False)),
+        "sticky": route.get("sticky", "none"),
+        "allow_http": bool(route.get("allow_http", False)),
+    }
+
+    normalized["health"] = normalize_health(route.get("health"))
+    normalized["tls"] = normalize_tls(route.get("tls"))
+    normalized["headers"] = normalize_headers(route.get("headers"))
+    rate_limit = normalize_rate_limit(route.get("rate_limit"))
+    if rate_limit:
+        normalized["rate_limit"] = rate_limit
+
+    if "basic_auth" in route and route["basic_auth"]:
+        normalized["basic_auth"] = route["basic_auth"]
+    if "mtls" in route and route["mtls"]:
+        normalized["mtls"] = route["mtls"]
+
+    return normalized
+
+
+def normalize_ingress(ingress: dict) -> dict:
+    normalized_routes = [normalize_route(route) for route in ingress.get("routes", [])]
+    return {
+        "enabled": ingress.get("enabled", True),
+        "routes": normalized_routes,
+    }
+
+
+def build_edge_config(
+    service: dict, normalized: dict, metadata: dict[str, Any]
+) -> List[Dict[str, Any]]:
+    if not normalized.get("enabled", True):
+        return []
+
+    service_id = service.get("service_id", "service")
+    primary_ip = service.get("service_ip")
+    if not primary_ip:
+        ports = service.get("service_ports", []) or []
+        if ports:
+            first_port = ports[0]
+            primary_ip = first_port.get("host_ip")
+    upstream_host = primary_ip or "127.0.0.1"
+
+    edge_entries: List[Dict[str, Any]] = []
+    for index, route in enumerate(normalized.get("routes", [])):
+        port = route["port"]
+        backend_name = f"{service_id}-{port}"
+        upstream_address = f"{upstream_host}:{port}"
+        upstream = {
+            "name": backend_name,
+            "host": upstream_host,
+            "port": port,
+            "address": upstream_address,
+            "health": route.get("health", {}),
+        }
+
+        entry_metadata = metadata | {
+            "route_index": index,
+            "route_host": route["host"],
+            "route_port": port,
+        }
+
+        edge_entry: Dict[str, Any] = {
+            "hostname": route["host"],
+            "path_prefix": route.get("path_prefix", "/"),
+            "tls": route.get("tls", {}),
+            "upstreams": [upstream],
+            "websocket": route.get("websocket", False),
+            "sticky": route.get("sticky", "none"),
+            "headers": route.get("headers", {}),
+            "metadata": entry_metadata,
+            "allow_http": route.get("allow_http", False),
+        }
+
+        if "rate_limit" in route:
+            edge_entry["rate_limit"] = route["rate_limit"]
+        if "basic_auth" in route:
+            edge_entry["basic_auth"] = route["basic_auth"]
+        if "mtls" in route:
+            edge_entry["mtls"] = route["mtls"]
+
+        edge_entries.append(edge_entry)
+
+    return edge_entries
+
+
+def compute_metadata(
+    managed_by: str, owner: str, service: dict, normalized: dict
+) -> dict[str, Any]:
+    spec_hash = hashlib.sha256(
+        json.dumps(normalized, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    ).hexdigest()
+    metadata = {
+        "managed_by": managed_by,
+        "owner": owner,
+        "service_id": service.get("service_id"),
+        "spec_hash": spec_hash,
+    }
+    return metadata
+
+
+def run_module() -> None:
+    module = AnsibleModule(
+        argument_spec={
+            "service": {"type": "dict", "required": True},
+            "schema_path": {"type": "path", "required": True},
+            "managed_by": {"type": "str", "required": True},
+            "owner": {"type": "str", "required": True},
+        },
+        supports_check_mode=True,
+    )
+
+    service: dict = module.params["service"] or {}
+    ingress_spec = service.get("ingress")
+
+    if not ingress_spec or not ingress_spec.get("enabled", True):
+        module.exit_json(
+            changed=False,
+            ingress_enabled=False,
+            normalized_ingress={},
+            edge_config=[],
+            metadata={},
+        )
+
+    schema_path = Path(module.params["schema_path"]).expanduser().resolve()
+    try:
+        schema = load_schema(schema_path)
+    except ValueError as exc:
+        module.fail_json(msg=str(exc))
+
+    validator = Draft202012Validator(schema)
+    try:
+        validator.validate(ingress_spec)
+    except Exception as exc:  # pragma: no cover - jsonschema gives detailed errors
+        module.fail_json(msg=f"Ingress spec failed validation: {exc}")
+
+    normalized = normalize_ingress(ingress_spec)
+    metadata = compute_metadata(
+        module.params["managed_by"], module.params["owner"], service, normalized
+    )
+    edge_config = build_edge_config(service, normalized, metadata)
+
+    module.exit_json(
+        changed=False,
+        ingress_enabled=True,
+        normalized_ingress=normalized,
+        edge_config=edge_config,
+        metadata=metadata,
+    )
+
+
+def main() -> None:
+    run_module()
+
+
+if __name__ == "__main__":
+    main()

--- a/roles/ingress_model/tasks/main.yml
+++ b/roles/ingress_model/tasks/main.yml
@@ -1,0 +1,37 @@
+---
+- name: Default ingress model service from service_spec
+  ansible.builtin.set_fact:
+    ingress_model_service: "{{ service_spec | default({}) }}"
+  when: ingress_model_service is not defined
+
+- name: Ensure ingress schema file exists
+  ansible.builtin.stat:
+    path: "{{ ingress_schema_path }}"
+  register: ingress_schema_stat
+
+- name: Validate ingress schema availability
+  ansible.builtin.assert:
+    that:
+      - ingress_schema_stat.stat.exists
+    fail_msg: >-
+      Ingress schema not found at {{ ingress_schema_path }}. Set ingress_schema_path to a valid file.
+
+- name: Determine ingress owner label
+  ansible.builtin.set_fact:
+    ingress_model_owner: >-
+      {{ ingress_owner | default(ingress_model_service.service_id | default('unknown')) }}
+
+- name: Build ingress model
+  ingress_model:
+    service: "{{ ingress_model_service }}"
+    schema_path: "{{ ingress_schema_path }}"
+    managed_by: "{{ ingress_managed_by }}"
+    owner: "{{ ingress_model_owner }}"
+  register: ingress_model_result
+
+- name: Register ingress modeling facts
+  ansible.builtin.set_fact:
+    ingress_enabled: "{{ ingress_model_result.ingress_enabled }}"
+    ingress_metadata: "{{ ingress_model_result.metadata | default({}) }}"
+    ingress_edge_config: "{{ ingress_model_result.edge_config | default([]) }}"
+    ingress_normalized: "{{ ingress_model_result.normalized_ingress | default({}) }}"

--- a/schemas/ingress.schema.yml
+++ b/schemas/ingress.schema.yml
@@ -1,0 +1,152 @@
+---
+$schema: "https://json-schema.org/draft/2020-12/schema"
+title: Ingress Intent
+description: Canonical ingress declaration for application services.
+type: object
+additionalProperties: false
+properties:
+  enabled:
+    type: boolean
+    default: true
+  routes:
+    type: array
+    minItems: 1
+    items:
+      type: object
+      required:
+        - host
+        - port
+      additionalProperties: true
+      properties:
+        host:
+          type: string
+          minLength: 1
+        port:
+          type: integer
+          minimum: 1
+          maximum: 65535
+        path_prefix:
+          type: string
+          default: "/"
+        websocket:
+          type: boolean
+          default: false
+        sticky:
+          type: string
+          enum: [none, ip, cookie]
+          default: none
+        health:
+          type: object
+          additionalProperties: false
+          properties:
+            path:
+              type: string
+              default: "/"
+            interval:
+              type: string
+              default: "30s"
+            timeout:
+              type: string
+              default: "5s"
+            method:
+              type: string
+            expected_status:
+              oneOf:
+                - type: integer
+                - type: array
+                  items:
+                    type: integer
+        tls:
+          type: object
+          additionalProperties: false
+          properties:
+            mode:
+              type: string
+              enum: [auto, provided, passthrough]
+              default: auto
+            hsts:
+              type: boolean
+              default: true
+            alpn:
+              type: array
+              items:
+                type: string
+              default:
+                - h2
+                - http/1.1
+            redirect_http_to_https:
+              type: boolean
+              default: true
+            acme:
+              type: object
+              additionalProperties: false
+              properties:
+                challenge:
+                  type: string
+                  enum: [http, dns]
+                  default: dns
+                dns_provider:
+                  type: string
+                email:
+                  type: string
+                wildcard:
+                  type: boolean
+                  default: false
+                eab_kid:
+                  type: string
+                eab_hmac_key:
+                  type: string
+            certificate_secret:
+              type: string
+            key_secret:
+              type: string
+            chain_secret:
+              type: string
+        headers:
+          type: object
+          additionalProperties: false
+          properties:
+            set:
+              type: array
+              items:
+                type: string
+              default: []
+            remove:
+              type: array
+              items:
+                type: string
+              default: []
+        rate_limit:
+          type: object
+          additionalProperties: false
+          properties:
+            requests_per_minute:
+              type: integer
+              minimum: 1
+            burst:
+              type: integer
+              minimum: 1
+        basic_auth:
+          type: object
+          additionalProperties: false
+          properties:
+            secret:
+              type: string
+            users:
+              type: array
+              items:
+                type: string
+        mtls:
+          type: object
+          additionalProperties: false
+          properties:
+            ca_secret:
+              type: string
+            required:
+              type: boolean
+              default: true
+        allow_http:
+          type: boolean
+          default: false
+required:
+  - routes

--- a/schemas/service.schema.yml
+++ b/schemas/service.schema.yml
@@ -83,6 +83,8 @@ properties:
     type: array
     items:
       type: string
+  ingress:
+    $ref: ingress.schema.yml
   service_unit:
     type: object
     properties:

--- a/tests/ingress_model.yml
+++ b/tests/ingress_model.yml
@@ -1,0 +1,29 @@
+---
+- name: Build ingress model for sample service
+  hosts: localhost
+  gather_facts: false
+  vars:
+    service_definition_file: "{{ service_definition_file | default('tests/sample_service_ingress.yml') }}"
+  tasks:
+    - name: Load service definition with ingress intent
+      ansible.builtin.include_vars:
+        file: "{{ service_definition_file }}"
+        name: service_spec
+
+    - name: Generate ingress model
+      ansible.builtin.include_role:
+        name: ingress_model
+
+    - name: Assert ingress model built
+      ansible.builtin.assert:
+        that:
+          - ingress_enabled | bool
+          - ingress_edge_config | length == 1
+          - ingress_edge_config[0].hostname == 'sample.example.test'
+          - ingress_edge_config[0].upstreams[0].host == service_spec.service_ip
+          - ingress_metadata.spec_hash is defined
+        fail_msg: "Ingress model generation failed"
+
+    - name: Display ingress edge configuration
+      ansible.builtin.debug:
+        var: ingress_edge_config

--- a/tests/sample_service_ingress.yml
+++ b/tests/sample_service_ingress.yml
@@ -1,0 +1,51 @@
+service_id: sample-service
+service_name: sample-service
+service_unit_name: sample-service
+service_image: docker.io/library/nginx:latest
+service_ip: 192.0.2.50
+service_ports:
+  - target: 8080
+    published: 8080
+    host_ip: 192.0.2.50
+ingress:
+  enabled: true
+  routes:
+    - host: sample.example.test
+      port: 8080
+      path_prefix: "/"
+      websocket: true
+      sticky: cookie
+      health:
+        path: "/internal/health"
+        interval: "10s"
+        timeout: "3s"
+      tls:
+        mode: auto
+        hsts: true
+        alpn: ["h2", "http/1.1"]
+        acme:
+          challenge: dns
+          dns_provider: cloudflare
+          email: admin@example.test
+          wildcard: false
+      headers:
+        set:
+          - "X-Frame-Options: DENY"
+          - "X-Content-Type-Options: nosniff"
+        remove:
+          - "Server"
+      rate_limit:
+        requests_per_minute: 900
+        burst: 150
+      basic_auth:
+        secret: vault_ingress_auth
+runtime_templates:
+  podman: ../templates/podman.yml.j2
+exports:
+  env: []
+mounts:
+  persistent_volumes: []
+  ephemeral_mounts: []
+health:
+  cmd:
+    - /bin/true

--- a/tests/samples/with_ingress.yml
+++ b/tests/samples/with_ingress.yml
@@ -1,0 +1,31 @@
+service_id: webapp
+service_name: Web Application
+service_image: ghcr.io/example/web:latest
+exports:
+  env:
+    - name: BASE_URL
+      value: https://web.example.test
+mounts:
+  persistent_volumes: []
+  ephemeral_mounts: []
+health:
+  cmd:
+    - /bin/true
+runtime_templates:
+  podman: ../templates/podman.yml.j2
+ingress:
+  enabled: true
+  routes:
+    - host: web.example.test
+      port: 8000
+      path_prefix: "/"
+      tls:
+        mode: auto
+        acme:
+          challenge: dns
+          dns_provider: cloudflare
+          email: ops@example.test
+      headers:
+        set:
+          - "X-Frame-Options: DENY"
+          - "X-Content-Type-Options: nosniff"


### PR DESCRIPTION
## Summary
- add a dedicated ingress intent schema and wire it into the service specification
- introduce an ingress_model role that validates and normalizes ingress blocks into edge configs
- provide sample definitions and a playbook exercising the new role for future integration tests

## Testing
- Attempted to run `python ci/validate_schema.py --examples tests/samples` *(fails: missing PyYAML in the execution environment because external package installs are blocked)*
- Attempted to run `ansible-playbook tests/ingress_model.yml` *(fails: ansible installation is blocked by the execution environment's proxy restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68f3efb5a8f0832eb4ae67663b75045c