### PR TITLE
Harden service schema defaults and template handling

### DIFF
--- a/roles/common/apply_runtime/tasks/docker.yml
+++ b/roles/common/apply_runtime/tasks/docker.yml
@@ -4,7 +4,7 @@
     compose_secret_env: "{{ secrets.env if secrets is defined and secrets.env is not none and secrets.env | length > 0 else [] }}"
     compose_secret_files: "{{ secrets.files if secrets is defined and secrets.files is not none and secrets.files | length > 0 else [] }}"
     compose_secret_env_path: "{{ runtime_output_dir }}/{{ service_name | default(service_id) }}.env"
-    compose_secret_shred: "{{ secrets.shred_after_apply | default(true) if secrets is defined else true }}"
+    compose_secret_shred: "{{ secrets.shred_after_apply if secrets is defined else true }}"
 
 - name: Write Compose secret environment file
   copy:

--- a/roles/common/apply_runtime/tasks/podman.yml
+++ b/roles/common/apply_runtime/tasks/podman.yml
@@ -14,7 +14,7 @@
   set_fact:
     quadlet_secret_env: "{{ secrets.env if secrets is defined and secrets.env is not none and secrets.env | length > 0 else [] }}"
     quadlet_secret_files: "{{ secrets.files if secrets is defined and secrets.files is not none and secrets.files | length > 0 else [] }}"
-    quadlet_secret_shred: "{{ secrets.shred_after_apply | default(true) if secrets is defined else true }}"
+    quadlet_secret_shred: "{{ secrets.shred_after_apply if secrets is defined else true }}"
 
 - name: Deduplicate quadlet secret environment variables
   set_fact:

--- a/schemas/ingress.schema.yml
+++ b/schemas/ingress.schema.yml
@@ -16,6 +16,7 @@ properties:
       required:
         - host
         - port
+        - path_prefix
       additionalProperties: false
       properties:
         host:

--- a/schemas/service.schema.yml
+++ b/schemas/service.schema.yml
@@ -17,10 +17,12 @@ properties:
     type: string
   service_image:
     type: string
+    pattern: "^.+@sha256:[0-9a-f]{64}$"
   service_ip:
     type: string
   service_port:
     type: object
+    deprecated: true
     properties:
       target:
         type: integer
@@ -179,11 +181,9 @@ properties:
       unprivileged:
         type: string
       features:
-        oneOf:
-          - type: string
-          - type: array
-            items:
-              type: string
+        type: array
+        items:
+          type: string
   needs_container_runtime:
     type: boolean
 

--- a/templates/docker.yml.j2
+++ b/templates/docker.yml.j2
@@ -26,7 +26,7 @@
   'container_name': service_name | default(service_id),
   'image': service_image,
   'env': service_env | default([]),
-  'ports': service_ports | default((service_port is defined) | ternary([service_port], [])),
+  'ports': service_ports | default([]),
   'volumes': service_volumes | default([]),
   'networks': service_networks | default(['app-network'])
 }]) %}

--- a/templates/kubernetes.yml.j2
+++ b/templates/kubernetes.yml.j2
@@ -38,9 +38,9 @@
 {% set health_timeout_seconds = (health.timeout | default('5s')) | regex_replace('s$', '') | int %}
 {% set health_retries = health.retries | default(3) %}
 {% set replicas = service_replicas | default(1) %}
-{% set ports = service_ports | default((service_port is defined) | ternary([service_port], [])) %}
+{% set ports = service_ports | default([]) %}
 {% set container_port = ports[0].target if ports | length > 0 else 8080 %}
-{% set service_port = ports[0].published if ports | length > 0 and ports[0].published is defined else container_port %}
+{% set service_port_value = ports[0].published if ports | length > 0 and ports[0].published is defined else container_port %}
 {% set resources = service_resources | default({'memory_mb': 256, 'cpu_cores': 1}) %}
 {% set memory_request = resources.memory_mb | default(256) %}
 {% set cpu_cores = resources.cpu_cores | default(1) %}
@@ -226,7 +226,7 @@ spec:
   selector:
     app: {{ svc_name }}
   ports:
-    - port: {{ service_port }}
+    - port: {{ service_port_value }}
       targetPort: {{ container_port }}
   type: ClusterIP
 {% if ingress_enabled and ingress_routes %}
@@ -252,13 +252,13 @@ spec:
     - host: {{ route.host }}
       http:
         paths:
-          - path: {{ route.path_prefix | default('/') }}
+          - path: {{ route.path_prefix }}
             pathType: Prefix
             backend:
               service:
                 name: {{ svc_name }}
                 port:
-                  number: {{ service_port }}
+                  number: {{ service_port_value }}
 {% endfor %}
 {% if tls_map %}
   tls:

--- a/templates/podman.yml.j2
+++ b/templates/podman.yml.j2
@@ -33,7 +33,7 @@
 {% endif %}
 {% set env_file_path = quadlet_base_dir ~ '/' ~ (service_name | default(service_id)) ~ '.env' %}
 {% set secret_dir = quadlet_base_dir ~ '/secrets' %}
-{% set ports = service_ports | default((service_port is defined) | ternary([service_port], [])) %}
+{% set ports = service_ports | default([]) %}
 {% set volumes = service_volumes | default([]) %}
 {% set inline_env = service_env | default([]) %}
 {% set auto_update_mode = quadlet_auto_update | default('none') %}

--- a/templates/proxmox.yml.j2
+++ b/templates/proxmox.yml.j2
@@ -33,13 +33,7 @@
 {% set feature_ns = namespace(value=None) %}
 {% if container.features is defined %}
   {% if container.features %}
-    {% if container.features is string %}
-      {% set feature_ns.value = container.features %}
-    {% elif container.features is sequence %}
-      {% set feature_ns.value = container.features | join(',') %}
-    {% else %}
-      {% set feature_ns.value = container.features | string %}
-    {% endif %}
+    {% set feature_ns.value = container.features | join(',') %}
   {% else %}
     {% set feature_ns.value = '' %}
   {% endif %}


### PR DESCRIPTION
## Summary
- enforce digest-pinned service images and rely on schema default for secret shredding
- normalize container feature handling and require ingress path prefixes from the schema
- remove single-port fallbacks so templates depend on the service_ports array

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68f40628fbf8832ea4fbc3f0b4316604