### PR TITLE
Document and validate dependency registries

### DIFF
--- a/ci/validate_schema.py
+++ b/ci/validate_schema.py
@@ -101,6 +101,12 @@ def build_parser() -> ArgumentParser:
         type=Path,
         help="Directory containing sample service definitions to validate",
     )
+    parser.add_argument(
+        "--dependency-registry",
+        type=Path,
+        action="append",
+        help="Path to dependency registry file(s) to validate against the registry schema",
+    )
     return parser
 
 
@@ -116,6 +122,43 @@ def main() -> int:
     schema, validator = schema_validation
 
     print("Schema validation succeeded.")
+
+    if args.dependency_registry:
+        registry_schema_validation = validate_schema(
+            Path("schemas/dependency-registry.schema.yml")
+        )
+        if isinstance(
+            registry_schema_validation, int
+        ):  # pragma: no cover - failure already logged
+            return registry_schema_validation
+
+        _, registry_validator = registry_schema_validation
+        registry_failures: list[str] = []
+        for registry_path in args.dependency_registry:
+            if not registry_path.exists():
+                registry_failures.append(
+                    f"Dependency registry file not found: {registry_path}"
+                )
+                continue
+            try:
+                registry_document = load_yaml(registry_path)
+            except ValueError as exc:
+                registry_failures.append(str(exc))
+                continue
+            try:
+                registry_validator.validate(registry_document)
+            except ValidationError as exc:
+                registry_failures.append(f"{registry_path}: {exc.message}")
+
+        if registry_failures:
+            for failure in registry_failures:
+                print(failure, file=sys.stderr)
+            return 1
+
+        print(
+            "Validated dependency registry files: "
+            + ", ".join(str(path) for path in args.dependency_registry)
+        )
 
     if args.examples:
         examples_dir = args.examples

--- a/docs/README.md
+++ b/docs/README.md
@@ -83,24 +83,40 @@ secrets:
       value: "{{ sample_service_tls_cert }}"
 ```
 
-Downstream applications consume these exports by resolving them through a dependency registry shared between repositories. Provide the registry as a list of known dependencies either inline (`dependency_registry`) or via `dependency_registry_file`:
+Downstream applications consume these exports by resolving them through a dependency registry shared between repositories. Provide the registry as a structured map of dependencies either inline (`dependency_registry`) or via `dependency_registry_file`:
 
 ```yaml
 # dependency-registry.yml
 dependencies:
-  - sample-service
-  - shared-cache
+  sample-service:
+    version: "1.27.0"
+    exports:
+      env:
+        - name: SAMPLE_SERVICE_URL
+          value: https://sample-service.internal
+    requires:
+      - name: shared-cache
+        version: "2024.05"
+  shared-cache:
+    exports:
+      env:
+        - name: SHARED_CACHE_URL
+          value: redis://shared-cache.internal:6379
 ```
 
 A dependent service can then declare its expectations and map resolved values (for example through a `dependency_exports` variable populated from the registry and exported environment files):
 
 ```yaml
 requires:
-  - sample-service
+  - name: sample-service
+    version: "1.27.0"
 
 service_env:
   - name: UPSTREAM_URL
     value: "{{ dependency_exports['sample-service'].SAMPLE_SERVICE_URL }}"
+
+The `requires` entries can also include an `exports_hash` if downstream services need
+to assert exact contract signatures instead of semantic versions.
 ```
 
 The registry keeps validation decoupled from the Ansible inventory while ensuring every declared dependency is fulfilled by an exported contract.

--- a/filter_plugins/dependency_registry.py
+++ b/filter_plugins/dependency_registry.py
@@ -1,0 +1,226 @@
+"""Filters for working with dependency registries and requirements."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from typing import Any
+
+
+def _normalize_requirement(item: Any) -> dict[str, Any]:
+    """Normalize a dependency requirement entry into a canonical mapping."""
+    if isinstance(item, str):
+        return {"name": item}
+    if isinstance(item, dict):
+        # Accept either already normalized mappings or minimal dicts.
+        if "name" in item and isinstance(item["name"], str):
+            normalized = {"name": item["name"]}
+            if item.get("version") is not None:
+                normalized["version"] = item["version"]
+            if item.get("exports_hash") is not None:
+                normalized["exports_hash"] = item["exports_hash"]
+            return normalized
+        # When provided as {service_name: {...}} allow the key to serve as name.
+        if len(item) == 1:
+            key, value = next(iter(item.items()))
+            if isinstance(value, dict):
+                normalized = {"name": key}
+                if value.get("version") is not None:
+                    normalized["version"] = value["version"]
+                if value.get("exports_hash") is not None:
+                    normalized["exports_hash"] = value["exports_hash"]
+                return normalized
+    raise ValueError(f"Unsupported requirement entry: {item!r}")
+
+
+def normalize_requirements(requirements: Any) -> list[dict[str, Any]]:
+    """Normalize requirement entries into canonical mappings."""
+    if not requirements:
+        return []
+    if isinstance(requirements, dict):
+        # Interpret mapping of name -> metadata.
+        normalized: list[dict[str, Any]] = []
+        for name, meta in requirements.items():
+            entry = {"name": name}
+            if isinstance(meta, dict):
+                if meta.get("version") is not None:
+                    entry["version"] = meta["version"]
+                if meta.get("exports_hash") is not None:
+                    entry["exports_hash"] = meta["exports_hash"]
+            normalized.append(entry)
+        return normalized
+    if isinstance(requirements, Iterable) and not isinstance(
+        requirements, (str, bytes)
+    ):
+        return [_normalize_requirement(item) for item in requirements]
+    return [_normalize_requirement(requirements)]
+
+
+def _normalize_dependency_entry(entry: Any) -> dict[str, Any]:
+    if entry is None:
+        return {}
+    if isinstance(entry, dict):
+        normalized: dict[str, Any] = {}
+        for key in ("version", "exports_hash", "exports"):
+            if entry.get(key) is not None:
+                normalized[key] = entry[key]
+        if "requires" in entry:
+            normalized["requires"] = normalize_requirements(entry["requires"])
+        return normalized
+    if isinstance(entry, str):
+        return {"version": entry} if entry else {}
+    raise ValueError(f"Unsupported dependency entry: {entry!r}")
+
+
+def normalize_dependency_registry(registry: Any) -> dict[str, dict[str, Any]]:
+    """Normalize registry input into a mapping of dependency name -> metadata."""
+    if not registry:
+        return {}
+
+    if isinstance(registry, (str, bytes)):
+        name = registry.decode() if isinstance(registry, bytes) else registry
+        return {name: {}}
+
+    if isinstance(registry, dict):
+        if "dependencies" in registry:
+            return normalize_dependency_registry(registry["dependencies"])
+        normalized: dict[str, dict[str, Any]] = {}
+        for name, value in registry.items():
+            if isinstance(value, dict) and "name" in value and value["name"] != name:
+                # Allow nested entries storing the name within their mapping.
+                entry_name = value["name"]
+                normalized[entry_name] = _normalize_dependency_entry(value)
+            else:
+                normalized[name] = _normalize_dependency_entry(value)
+        return normalized
+
+    if isinstance(registry, Iterable) and not isinstance(registry, (str, bytes)):
+        normalized: dict[str, dict[str, Any]] = {}
+        for item in registry:
+            if isinstance(item, str):
+                normalized[item] = {}
+            elif isinstance(item, dict):
+                if "name" not in item:
+                    raise ValueError(f"Dependency entry missing name: {item!r}")
+                name = item["name"]
+                normalized[name] = _normalize_dependency_entry(item)
+            else:
+                raise ValueError(f"Unsupported dependency registry entry: {item!r}")
+        return normalized
+
+    raise ValueError(f"Unsupported dependency registry value: {registry!r}")
+
+
+def merge_dependency_registries(registries: Iterable[Any]) -> dict[str, dict[str, Any]]:
+    """Merge multiple registry fragments into a single normalized mapping."""
+    result: dict[str, dict[str, Any]] = {}
+    for registry in registries or []:
+        if not registry:
+            continue
+        normalized = normalize_dependency_registry(registry)
+        for name, metadata in normalized.items():
+            existing = result.get(name, {})
+            merged = existing.copy()
+            for key, value in metadata.items():
+                if key == "requires":
+                    existing_requires = normalize_requirements(
+                        merged.get("requires", [])
+                    )
+                    new_requires = normalize_requirements(value)
+                    merged["requires"] = _merge_requirements(
+                        existing_requires, new_requires
+                    )
+                else:
+                    merged[key] = value
+            result[name] = merged
+    return result
+
+
+def _merge_requirements(
+    existing: list[dict[str, Any]], new: list[dict[str, Any]]
+) -> list[dict[str, Any]]:
+    merged: dict[str, dict[str, Any]] = {item["name"]: item for item in existing}
+    for item in new:
+        name = item["name"]
+        if name not in merged:
+            merged[name] = item
+            continue
+        merged_item = merged[name].copy()
+        for key in ("version", "exports_hash"):
+            if item.get(key) is not None:
+                merged_item[key] = item[key]
+        merged[name] = merged_item
+    return list(merged.values())
+
+
+def dependency_graph_cycles(
+    registry: Any, current_service: str | None = None, current_requires: Any = None
+) -> list[str]:
+    """Return dependency cycles detected within the registry and current service."""
+    normalized_registry = (
+        registry
+        if isinstance(registry, dict)
+        else normalize_dependency_registry(registry)
+    )
+    graph: dict[str, list[str]] = {}
+
+    for name, metadata in normalized_registry.items():
+        requires = normalize_requirements(metadata.get("requires", []))
+        graph[name] = [item["name"] for item in requires if item.get("name")]
+
+    if current_service:
+        requires = normalize_requirements(current_requires)
+        graph[current_service] = [item["name"] for item in requires if item.get("name")]
+        for req in graph[current_service]:
+            graph.setdefault(req, [])
+
+    return _find_cycles(graph)
+
+
+def _find_cycles(graph: dict[str, list[str]]) -> list[str]:
+    cycles: set[tuple[str, ...]] = set()
+    stack: list[str] = []
+    visiting: set[str] = set()
+    visited: set[str] = set()
+
+    def visit(node: str) -> None:
+        if node in visiting:
+            cycle = stack[stack.index(node) :] + [node]
+            cycles.add(_canonical_cycle(tuple(cycle)))
+            return
+        if node in visited:
+            return
+
+        visiting.add(node)
+        stack.append(node)
+        for neighbor in graph.get(node, []):
+            visit(neighbor)
+        stack.pop()
+        visiting.remove(node)
+        visited.add(node)
+
+    for node in graph.keys():
+        if node not in visited:
+            visit(node)
+
+    return [" -> ".join(cycle + (cycle[0],)) for cycle in sorted(cycles)]
+
+
+def _canonical_cycle(cycle: tuple[str, ...]) -> tuple[str, ...]:
+    if not cycle:
+        return cycle
+    unique = cycle[:-1]
+    min_index = min(range(len(unique)), key=lambda i: unique[i])
+    rotated = unique[min_index:] + unique[:min_index]
+    return tuple(rotated)
+
+
+class FilterModule:
+    """Ansible filter plugin entrypoint."""
+
+    def filters(self) -> dict[str, Any]:
+        return {
+            "normalize_dependency_registry": normalize_dependency_registry,
+            "merge_dependency_registries": merge_dependency_registries,
+            "normalize_requirements": normalize_requirements,
+            "dependency_graph_cycles": dependency_graph_cycles,
+        }

--- a/roles/common/render_runtime/tasks/main.yml
+++ b/roles/common/render_runtime/tasks/main.yml
@@ -11,6 +11,35 @@
       {{ mounts.ephemeral_mounts | default([]) | map(attribute='path') | list }}
   when: mounts is defined and mounts.ephemeral_mounts is defined
 
+- name: Normalize service dependency requirements
+  set_fact:
+    render_service_requires: "{{ requires | default([]) | normalize_requirements }}"
+  when: requires is defined
+
+- name: Ensure dependency exports provided for required services
+  assert:
+    that:
+      - dependency_exports is defined
+      - dependency_exports is mapping
+    fail_msg: >-
+      Service {{ service_id }} declares dependencies but dependency_exports is not provided.
+  when:
+    - render_service_requires is defined
+    - render_service_requires | length > 0
+
+- name: Validate required dependency exports are available
+  assert:
+    that:
+      - item.name in dependency_exports
+    fail_msg: >-
+      Required dependency {{ item.name }} missing from dependency_exports.
+  loop: "{{ render_service_requires | default([]) }}"
+  loop_control:
+    label: "{{ item.name }}"
+  when:
+    - render_service_requires is defined
+    - render_service_requires | length > 0
+
 - name: Validate ephemeral mounts excluded from persistent backups
   assert:
     that:

--- a/roles/common/validate_schema/tasks/main.yml
+++ b/roles/common/validate_schema/tasks/main.yml
@@ -16,62 +16,85 @@
       - runtime_templates is defined
     fail_msg: "Service {{ service_id | default('unknown') }} is missing required contract fields"
 
-- name: Initialize dependency registry
+- name: Initialize dependency registry sources
   set_fact:
-    dependency_registry_entries: []
+    dependency_registry_sources: []
 
 - name: Load dependency registry from file
   set_fact:
     dependency_registry_source: "{{ lookup('file', dependency_registry_file) | from_yaml }}"
   when: dependency_registry_file is defined
 
-- name: Normalize dependency registry from file
+- name: Append dependency registry from file
   set_fact:
-    dependency_registry_entries: >-
-      {{
-        dependency_registry_entries
-        + (
-          dependency_registry_source.dependencies
-          if (dependency_registry_source is mapping and dependency_registry_source.dependencies is defined)
-          else (
-            dependency_registry_source.keys() | list
-            if dependency_registry_source is mapping
-            else (
-              [dependency_registry_source]
-              if dependency_registry_source is string
-              else (dependency_registry_source | default([]))
-            )
-          )
-        )
-      }}
+    dependency_registry_sources: >-
+      {{ dependency_registry_sources + [dependency_registry_source] }}
   when: dependency_registry_file is defined
 
-- name: Append inline dependency registry entries
+- name: Append inline dependency registry
   set_fact:
-    dependency_registry_entries: >-
+    dependency_registry_sources: >-
       {{
-        dependency_registry_entries
-        + (
-          [dependency_registry]
-          if dependency_registry is string
-          else (dependency_registry | default([]))
-        )
+        dependency_registry_sources
+        + [dependency_registry]
       }}
   when: dependency_registry is defined
 
-- name: Deduplicate dependency registry entries
+- name: Normalize dependency registry
   set_fact:
-    dependency_registry_entries: "{{ dependency_registry_entries | default([]) | unique }}"
+    dependency_registry_entries: >-
+      {{ dependency_registry_sources | default([]) | merge_dependency_registries }}
 
-- name: Validate required dependencies exist
+- name: Normalize service requirements
+  set_fact:
+    service_requires_normalized: "{{ requires | default([]) | normalize_requirements }}"
+  when: requires is defined
+
+- name: Validate dependency version requirements when available
   assert:
     that:
-      - item in dependency_registry_entries
+      - dependency_registry_entries[item.name].version is defined
+      - dependency_registry_entries[item.name].version == item.version
     fail_msg: >-
-      Required dependency {{ item }} not found in dependency registry. Provide
-      dependency_registry or dependency_registry_file with available exports.
-  loop: "{{ requires | default([]) }}"
-  when: requires is defined and requires | length > 0
+      Dependency {{ item.name }} version mismatch. Required {{ item.version | default('unspecified') }},
+      registry provides {{ dependency_registry_entries[item.name].version if item.name in dependency_registry_entries else 'none' }}.
+  loop: "{{ service_requires_normalized | default([]) }}"
+  loop_control:
+    label: "{{ item.name }}"
+  when:
+    - service_requires_normalized is defined
+    - service_requires_normalized | length > 0
+    - item.version is defined
+    - item.name in dependency_registry_entries
+
+- name: Validate dependency exports hash requirements when available
+  assert:
+    that:
+      - dependency_registry_entries[item.name].exports_hash is defined
+      - dependency_registry_entries[item.name].exports_hash == item.exports_hash
+    fail_msg: >-
+      Dependency {{ item.name }} exports hash mismatch. Required {{ item.exports_hash | default('unspecified') }},
+      registry provides {{ dependency_registry_entries[item.name].exports_hash if item.name in dependency_registry_entries else 'none' }}.
+  loop: "{{ service_requires_normalized | default([]) }}"
+  loop_control:
+    label: "{{ item.name }}"
+  when:
+    - service_requires_normalized is defined
+    - service_requires_normalized | length > 0
+    - item.exports_hash is defined
+    - item.name in dependency_registry_entries
+
+- name: Detect dependency cycles
+  set_fact:
+    dependency_cycle_paths: >-
+      {{ dependency_registry_entries | dependency_graph_cycles(service_id, service_requires_normalized | default([])) }}
+
+- name: Validate dependency graph has no cycles
+  assert:
+    that:
+      - dependency_cycle_paths | default([]) | length == 0
+    fail_msg: >-
+      Dependency cycle detected: {{ dependency_cycle_paths | join('; ') }}
 
 - name: Validate secret environment values are not placeholders
   assert:

--- a/schemas/dependency-registry.schema.yml
+++ b/schemas/dependency-registry.schema.yml
@@ -1,0 +1,83 @@
+---
+title: Dependency Registry Schema
+type: object
+required:
+  - dependencies
+properties:
+  dependencies:
+    description: Mapping of dependency service names to their exported contracts.
+    oneOf:
+      - type: object
+        additionalProperties:
+          $ref: "#/$defs/dependency"
+      - type: array
+        items:
+          anyOf:
+            - type: string
+            - $ref: "#/$defs/dependency"
+additionalProperties: false
+$defs:
+  requirement:
+    type: object
+    required:
+      - name
+    properties:
+      name:
+        type: string
+      version:
+        type: string
+      exports_hash:
+        type: string
+    additionalProperties: false
+  dependency:
+    type: object
+    properties:
+      name:
+        type: string
+      version:
+        type: string
+      exports_hash:
+        type: string
+      requires:
+        type: array
+        items:
+          anyOf:
+            - type: string
+            - $ref: "#/$defs/requirement"
+      exports:
+        $ref: "#/$defs/exports"
+    additionalProperties: true
+  exports:
+    type: object
+    properties:
+      env:
+        type: array
+        items:
+          type: object
+          required:
+            - name
+            - value
+          properties:
+            name:
+              type: string
+            value:
+              type: string
+            description:
+              type: string
+      files:
+        type: array
+        items:
+          type: object
+          required:
+            - name
+            - value
+          properties:
+            name:
+              type: string
+            value:
+              type: string
+            target:
+              type: string
+            description:
+              type: string
+    additionalProperties: true

--- a/schemas/service.schema.yml
+++ b/schemas/service.schema.yml
@@ -194,7 +194,18 @@ properties:
   requires:
     type: array
     items:
-      type: string
+      anyOf:
+        - type: string
+        - type: object
+          required:
+            - name
+          properties:
+            name:
+              type: string
+            version:
+              type: string
+            exports_hash:
+              type: string
   exports:
     type: object
     properties:

--- a/tests/dependency_registry.yml
+++ b/tests/dependency_registry.yml
@@ -1,0 +1,18 @@
+---
+dependencies:
+  sample-service:
+    version: "1.27.0"
+    exports_hash: "b6a8fbea0c94d6b5f7713b09363eb76a5cb5824ef1ed2fa2cec0f1a8f08fd0c2"
+    exports:
+      env:
+        - name: SAMPLE_SERVICE_URL
+          value: https://sample-service.internal
+    requires:
+      - name: shared-cache
+        version: "2024.05"
+  shared-cache:
+    version: "2024.05"
+    exports:
+      env:
+        - name: SHARED_CACHE_URL
+          value: redis://shared-cache.internal:6379


### PR DESCRIPTION
## Summary
- add a formal dependency registry schema and allow the validation CLI to check registry files
- introduce filter utilities that normalize registries, detect dependency cycles, and verify version or export hash requirements
- fail fast when required dependency exports are missing and document the richer registry/requirement contract

## Testing
- python ci/validate_schema.py --dependency-registry tests/dependency_registry.yml *(fails: ModuleNotFoundError: No module named 'yaml')*


------
https://chatgpt.com/codex/tasks/task_e_68f4061ced9c832ebadef3eeb84c9167