### PR TITLE
Add ops documentation and enforce version compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,6 +95,9 @@ jobs:
           chmod +x /tmp/kubectl
           sudo mv /tmp/kubectl /usr/local/bin/kubectl
 
+      - name: Verify compatibility matrix
+        run: python ci/verify_versions.py
+
       - name: Run gitleaks
         run: gitleaks detect --no-banner --redact --source .
 

--- a/ci/verify_versions.py
+++ b/ci/verify_versions.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+"""Assert that toolchain versions stay within the documented compatibility matrix."""
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+import sys
+from typing import List
+
+ALLOWED = {
+    "python": ("3.11.",),
+    "ansible": ("9.5.",),
+    "ansible_core": ("2.16.",),
+    "kubectl": ("v1.29.3", "v1.31.1"),
+}
+
+
+def run_command(command: List[str]) -> subprocess.CompletedProcess[str]:
+    """Execute *command* returning the completed process with UTF-8 text."""
+
+    return subprocess.run(command, check=True, capture_output=True, text=True)
+
+
+def check_python() -> List[str]:
+    version = sys.version.split()[0]
+    if not version.startswith(ALLOWED["python"]):
+        return [f"Python {version} is outside the supported {ALLOWED['python']} range."]
+    return []
+
+
+def check_ansible() -> List[str]:
+    errors: List[str] = []
+
+    try:
+        pip_info = run_command([sys.executable, "-m", "pip", "show", "ansible"])
+    except subprocess.CalledProcessError as exc:  # pragma: no cover - defensive guard
+        errors.append(
+            "Unable to determine ansible version via pip: " + exc.stderr.strip()
+        )
+    else:
+        version_match = re.search(
+            r"^Version:\s*(?P<version>\S+)$", pip_info.stdout, re.MULTILINE
+        )
+        if not version_match:
+            errors.append("ansible package version could not be parsed.")
+        else:
+            version = version_match.group("version")
+            if not version.startswith(ALLOWED["ansible"]):
+                errors.append(
+                    f"Ansible package {version} is outside the supported {ALLOWED['ansible']} range."
+                )
+
+    try:
+        ansible_out = run_command(["ansible", "--version"])
+    except subprocess.CalledProcessError as exc:  # pragma: no cover - defensive guard
+        errors.append("Unable to execute ansible --version: " + exc.stderr.strip())
+    except FileNotFoundError:  # pragma: no cover - defensive guard
+        errors.append("ansible binary not found in PATH.")
+    else:
+        match = re.search(r"ansible \[core (?P<version>[\d.]+)\]", ansible_out.stdout)
+        if not match:
+            errors.append(
+                "ansible --version output did not contain a core version identifier."
+            )
+        else:
+            version = match.group("version")
+            if not version.startswith(ALLOWED["ansible_core"]):
+                errors.append(
+                    f"ansible-core {version} is outside the supported {ALLOWED['ansible_core']} range."
+                )
+
+    return errors
+
+
+def check_kubectl() -> List[str]:
+    errors: List[str] = []
+
+    try:
+        result = run_command(["kubectl", "version", "--client", "--output", "json"])
+    except subprocess.CalledProcessError as exc:  # pragma: no cover - defensive guard
+        errors.append("kubectl version command failed: " + exc.stderr.strip())
+        return errors
+    except FileNotFoundError:  # pragma: no cover - defensive guard
+        errors.append("kubectl binary not found in PATH.")
+        return errors
+
+    try:
+        payload = json.loads(result.stdout)
+    except json.JSONDecodeError as exc:  # pragma: no cover - defensive guard
+        errors.append(f"kubectl returned invalid JSON: {exc}")
+        return errors
+
+    git_version = payload.get("clientVersion", {}).get("gitVersion")
+    if not git_version:
+        errors.append(
+            "kubectl clientVersion.gitVersion was missing from the JSON payload."
+        )
+    elif git_version not in ALLOWED["kubectl"]:
+        allowed = ", ".join(ALLOWED["kubectl"])
+        errors.append(f"kubectl {git_version} is outside the supported set: {allowed}.")
+
+    return errors
+
+
+CHECKS = (check_python, check_ansible, check_kubectl)
+
+
+def main() -> int:
+    failures: List[str] = []
+    for check in CHECKS:
+        failures.extend(check())
+
+    if failures:
+        for failure in failures:
+            print(f"::error::{failure}")
+        return 1
+
+    print("All toolchain versions fall within the documented compatibility matrix.")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    raise SystemExit(main())

--- a/docs/README.md
+++ b/docs/README.md
@@ -28,6 +28,15 @@ ansible-playbook tests/render.yml -e runtime=docker -e @tests/sample_service.yml
 
 The rendered manifest is written to `/tmp/ansible-runtime/<service_id>/<runtime>.yml` and can be validated with the same commands used in CI (for example `docker compose -f … config`).
 
+## Compatibility Matrix
+
+| Component | Tested versions | Notes |
+| --- | --- | --- |
+| Python | 3.11.x | Provisioned via `actions/setup-python` and verified during CI. |
+| Ansible | Ansible 9.5.1 (core 2.16.x) | Locked in `requirements.txt` and exercised across every adapter lane. |
+| Kubernetes CLI | kubectl v1.29.3 (stable lane), v1.31.1 (latest lane) | Both versions render and validate manifests in the matrix build. |
+| kind | v0.22.0 | Used for server-side Kubernetes validation. |
+
 ## Runtime Guides
 
 - [Proxmox LXC](proxmox.md)
@@ -36,6 +45,11 @@ The rendered manifest is written to `/tmp/ansible-runtime/<service_id>/<runtime>
 - [Kubernetes](kubernetes.md)
 - [Bare-Metal systemd](baremetal.md)
 - [Network Edge Automation](edge.md)
+
+## Operations Guides
+
+- [Backup strategy](backup.md)
+- [Troubleshooting](troubleshooting.md)
 
 ## Service Contract Essentials
 
@@ -82,6 +96,8 @@ secrets:
       target: /etc/sample-service/certs/tls.crt
       value: "{{ sample_service_tls_cert }}"
 ```
+
+> **Note:** Always declare host mounts with `service_volumes` (plural). The legacy `service_volume` key is deprecated and retained only for backward compatibility with older inventories.
 
 Downstream applications consume these exports by resolving them through a dependency registry shared between repositories. Provide the registry as a list of known dependencies either inline (`dependency_registry`) or via `dependency_registry_file`:
 

--- a/docs/backup.md
+++ b/docs/backup.md
@@ -1,0 +1,137 @@
+# Backup strategy
+
+Persistent data is declared in each service contract through `mounts.persistent_volumes`.
+Every runtime adapter exposes those directories on the host so they can be backed
+up without reverse-engineering container layouts. This guide shows how to locate
+those paths per runtime and how to couple them with a Restic-based backup
+pipeline.
+
+## Core principles
+
+1. **Back up the host paths, not container paths.** The adapters bind the
+   declared volumes into the workload. Use the host-side source when scheduling
+   backups.
+2. **Leverage `service_volumes` for bind mounts.** Host paths declared under
+   `service_volumes` align with the persistent volume list; keep them in sync so
+   the documentation doubles as a recovery plan.
+3. **Record retention and prune policies.** Restic handles deduplication and
+   pruning, but it still needs explicit `forget --prune` policies. Bake them into
+   timers or CI pipelines.
+
+## Runtime-specific guidance
+
+### Docker Compose
+
+- Host bind mounts: defined directly in `service_volumes`. Back up the host paths
+  (for example `/srv/<service>/config`).
+- Named volumes: when `service_volumes` is omitted, Compose falls back to
+  managed volumes under `/var/lib/docker/volumes/<volume>/_data`. Use `docker
+  volume inspect` to confirm the path before scheduling backups.
+- Example Restic invocation:
+
+  ```bash
+  RESTIC_REPOSITORY=s3:https://s3.example.com/infrastructure \
+  RESTIC_PASSWORD_FILE=/etc/restic/password \
+  restic backup /srv/sample-service/config
+  ```
+
+### Podman Quadlet
+
+- Quadlet binds the same `service_volumes` entries under `/srv` (or the host path
+  you declare). Back them up directly.
+- Named volumes live under `/var/lib/containers/storage/volumes/<volume>/_data`.
+  Use `podman volume inspect` to retrieve the path before calling Restic.
+- Example systemd timer excerpt using Restic:
+
+  ```ini
+  [Unit]
+  Description=Restic backup for sample-service
+
+  [Service]
+  Type=oneshot
+  Environment=RESTIC_REPOSITORY=s3:https://s3.example.com/infrastructure
+  Environment=RESTIC_PASSWORD_FILE=/etc/restic/password
+  ExecStart=/usr/local/bin/restic backup /srv/sample-service/config
+
+  [Install]
+  WantedBy=timers.target
+  ```
+
+### Kubernetes
+
+- Persistent data is expressed via `PersistentVolumeClaim`s sized from
+  `service_storage_gb` or `service_storage_size`. When `service_volumes.host_path`
+  is present the adapters wire the node path directly.
+- Backup options:
+  - Use a CSI snapshot/restore workflow if the storage class supports it.
+  - Pair the cluster with [Velero](https://velero.io/) and enable its Restic
+    integration for file-level backups of each PVC.
+  - For hostPath mounts, schedule Restic on the node to back up the declared
+    directories.
+- Example Restic DaemonSet snippet targeting hostPath-backed workloads:
+
+  ```yaml
+  apiVersion: apps/v1
+  kind: DaemonSet
+  metadata:
+    name: restic-backup
+  spec:
+    template:
+      spec:
+        serviceAccountName: restic
+        containers:
+          - name: restic
+            image: ghcr.io/restic/restic:0.16.4
+            envFrom:
+              - secretRef:
+                  name: restic-credentials
+            volumeMounts:
+              - name: data
+                mountPath: /data
+            command: ["/bin/sh","-c","restic backup /data"]
+        volumes:
+          - name: data
+            hostPath:
+              path: /srv/sample-service/config
+  ```
+
+### Proxmox LXC
+
+- LXC containers can mount directories from the Proxmox host when `service_volumes`
+  is populated. Back up the host directories or use `vzdump` snapshots for
+  container-level protection.
+- Combine `vzdump` with Restic by exporting the resulting tarballs:
+
+  ```bash
+  vzdump 105 --dumpdir /var/backups/lxc
+  RESTIC_REPOSITORY=rest:http://backup-gateway:8000/infra restic backup /var/backups/lxc
+  ```
+
+### Bare-metal systemd
+
+- Bare-metal adapters create directories listed in `mounts.persistent_volumes`
+  directly on the target host. Schedule Restic timers targeting those paths.
+- Example Ansible snippet that renders a shared timer for all services:
+
+  ```yaml
+  - name: Configure Restic backups
+    include_role:
+      name: restic
+    vars:
+      restic_backup_paths: "{{ mounts.persistent_volumes | map(attribute='path') | list }}"
+  ```
+
+## Restic integration checklist
+
+1. Create a `restic` user or systemd service account with access to every
+   persistent path.
+2. Store credentials (`RESTIC_PASSWORD`, repository credentials) in Ansible
+   vaults or secret stores; surface them as environment files during runtime.
+3. Schedule both `restic backup` and `restic forget --prune` operations. Use
+   timers on bare metal/Quadlet hosts or Kubernetes CronJobs.
+4. Regularly run `restic check` to detect repository corruption early.
+5. Document restore commands alongside each service so on-call engineers can
+   rehearse recovery without trawling through inventories.
+
+The combination of declarative volume metadata and Restic automation keeps data
+portable across runtimes and simplifies disaster recovery drills.

--- a/docs/edge.md
+++ b/docs/edge.md
@@ -81,7 +81,8 @@ Traefik entrypoint), and exposes a structured `edge_ingress_backends` variable.
 Renders a file-provider configuration at `/etc/traefik/dynamic/ingress.yml`. The
 configuration builds one router and service per backend and honours TLS and
 middleware hints from the contract. Reloads are issued via `systemctl reload
-traefik` by default.
+traefik` by default and are preceded by `traefik --validate=true` to catch
+syntax errors before the service restarts.
 
 ### `edge_proxy_haproxy`
 
@@ -91,6 +92,68 @@ issued using the path prefix (or `/` by default). The generated configuration is
 validated with `haproxy -c -f` before the service reloads, ensuring syntax
 errors never reach production. The handler then reloads HAProxy using the
 configured command.
+
+The rendered configuration defaults to `/usr/local/etc/haproxy/ingress.cfg` and
+respects the variables defined in `roles/edge_proxy_haproxy/defaults/main.yml`.
+Key toggles include:
+
+- `haproxy_bind_http` / `haproxy_http_bind_address` – enable and control the
+  clear-text listener (defaults to `*:80`).
+- `haproxy_bind_https` / `haproxy_https_bind_address` – enable TLS termination
+  when paired with a PEM bundle exposed through `haproxy_https_cert`.
+- `haproxy_default_options` – append stock HAProxy options (`httplog`,
+  `forwardfor`, etc.) to the `defaults` block.
+
+When a service publishes `path_prefix` values the role emits the ACL wiring
+required to restrict routes. Health checks follow that same prefix so upstreams
+must respond with success codes. A minimal HTTP-only render for an
+`auth-service` backend looks like:
+
+```haproxy
+global
+  maxconn 2048
+
+defaults
+  mode http
+  timeout connect 5s
+  timeout client  50s
+  timeout server  50s
+  option httplog
+  option dontlognull
+  option http-server-close
+  option forwardfor
+
+frontend http_ingress
+  bind *:80
+  mode http
+  acl host_auth-service hdr(host) -i auth.internal.example
+  use_backend auth-service if host_auth-service
+
+backend auth-service
+  mode http
+  option httpchk
+  http-check send meth GET uri /
+  server auth-service 10.10.12.8:8443 check
+```
+
+Enabling TLS termination only requires toggling `haproxy_bind_https: true` and
+pointing `haproxy_https_cert` at a PEM bundle containing the certificate chain
+and private key. The role emits a dedicated `https_ingress` frontend that shares
+the same ACL logic:
+
+```haproxy
+frontend https_ingress
+  bind *:443 ssl crt /usr/local/etc/haproxy/tls.pem
+  mode http
+  acl host_auth-service hdr(host) -i auth.internal.example
+  use_backend auth-service if host_auth-service
+```
+
+Middleware-style hints, such as header rewrites or prefix stripping, can be
+implemented by extending the template or injecting static configuration via
+`haproxy_extra_config` blocks before reloading. The role keeps the generated
+section isolated so operators can include additional `backend` or `frontend`
+snippets through native HAProxy includes.
 
 ### `edge_opnsense`
 
@@ -138,13 +201,19 @@ configuration posts to `/api/v1/services/squid/reverse_proxy` and applies with
 the standard `/api/v1/services/squid/apply` endpoint when
 `pfsense_squid_apply_changes` is true (default).
 
-### `edge_proxy_traefik`
+## Middleware support matrix
 
-Renders a file-provider configuration at `/etc/traefik/dynamic/ingress.yml`. The
-configuration builds one router and service per backend and honours TLS and
-middleware hints from the contract. Reloads are issued via `systemctl reload
-traefik` by default and are now preceded by `traefik --validate=true` to catch
-syntax errors before the service restarts.
+The ingress contract exposes several optional hints. The table below summarises
+which adapters consume them without additional customization:
+
+| Capability | Traefik (file provider) | HAProxy (stand-alone) | OPNsense HAProxy | OPNsense Nginx | OPNsense Caddy | pfSense HAProxy | pfSense Squid |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| Host-based routing | ✅ routers honour `APP_FQDN` | ✅ ACLs route by host header | ✅ Frontends match host rules | ✅ Server blocks map hosts | ✅ Route matchers mirror host | ✅ Frontends match host rules | ✅ Reverse proxy entries keyed by host |
+| Path prefix routing | ✅ `PathPrefix` rules per backend | ✅ ACLs guard per-prefix routes | ✅ Additional HAProxy rules generated | ✅ Location blocks per prefix | ✅ Matchers include prefix | ✅ Additional HAProxy rules generated | ✅ Reverse proxy paths per backend |
+| TLS termination | ✅ Per-backend toggle via `tls`/`tls_certresolver` | ⚠️ Global via `haproxy_bind_https`; requires PEM bundle | ✅ Controlled by `opnsense_ingress_bind_addresses` + `tls` | ✅ Controlled by bind definitions and certificate IDs | ✅ Automatically emits TLS policies when `tls` is true | ✅ Controlled by bind definitions and certificate IDs | ⚠️ Relies on upstream TLS; Squid terminates HTTPS only when configured globally |
+| Middleware / header rewrites | ✅ `middlewares` list mapped directly | ⚠️ Manual via template extension or includes | ⚠️ Requires custom automation against OPNsense API | ⚠️ Requires custom directives | ⚠️ Requires custom directives | ⚠️ Requires custom automation | ⚠️ Requires manual ACL configuration |
+| Preserve/forward host headers | ✅ `passHostHeader` and `preserve_host` flags supported | ✅ Backend servers receive host header by default | ✅ Backends inherit original headers | ✅ Upstreams preserve headers | ✅ Upstreams preserve headers | ✅ Backends inherit original headers | ⚠️ Requires custom squid tweaks |
+| HTTP health checks | ✅ Traefik reuses backend URL | ✅ `option httpchk` per backend | ✅ HTTP checks configured per backend | ✅ Health checks per upstream | ✅ Health checks per upstream | ✅ HTTP checks configured per backend | ✅ Health monitoring via reverse-proxy checks |
 
 ## Security considerations
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,86 @@
+# Troubleshooting guide
+
+Use this checklist when a deployment fails. Each section outlines common
+symptoms, commands to confirm the root cause, and remediation guidance.
+
+## Secret validation failures
+
+**Symptoms**
+- `ci/validate_schema.py` or `edge_ingress` tasks report missing secret keys.
+- `ansible-playbook` aborts with `Undefined variable` when templating
+  `secrets.env` or `secrets.files` entries.
+
+**Debugging steps**
+- Run `ansible-playbook tests/render.yml -e service_definition_file=<file>` to
+  reproduce the render locally with verbose output.
+- Inspect `secrets.env` and `secrets.files` arrays; confirm every item contains a
+  `name` and `value` (and `target` for file entries).
+- Verify inventory group_vars define each templated secret or that the CI
+  environment injects them via `ANSIBLE_VAULT_PASSWORD_FILE`.
+
+**Fix**
+- Add missing variables to the inventory or vault.
+- Set `secrets.shred_after_apply: false` temporarily to inspect rendered secret
+  files under `/tmp/ansible-runtime/<service>/`.
+
+## Image pull errors
+
+**Symptoms**
+- Runtime adapters fail with `image pull` errors.
+- CI logs show `manifest unknown` or authentication failures from registries.
+
+**Debugging steps**
+- Confirm the image digest in `service_image` exists (`skopeo inspect` or `podman
+  pull`).
+- Ensure the runtime host has credentials for private registries. Compose and
+  Quadlet read from `~/.docker/config.json`; Kubernetes uses image pull secrets.
+- For Proxmox LXC, verify the template is mirrored locally or accessible through
+  `pveam`.
+
+**Fix**
+- Promote new image digests intentionally and update `service_image`.
+- Sync credential helpers or Kubernetes secrets before rerunning the playbook.
+
+## Dependency resolution loops
+
+**Symptoms**
+- `edge_ingress` or service-specific roles hang while waiting for dependencies to
+  appear.
+- Logs show repeated attempts to resolve `dependency_exports` entries.
+
+**Debugging steps**
+- Check `requires` in the service definition; ensure every dependency is listed
+  in the registry consumed by `dependency_exports`.
+- Use `ansible-inventory --graph` to confirm the dependency service is assigned
+  to a host and rendered successfully.
+- Inspect the exported `.env` files to confirm they contain the expected keys
+  (`APP_FQDN`, `APP_PORT`, `APP_BACKEND_IP`).
+
+**Fix**
+- Add missing dependencies to the registry file.
+- Re-run the upstream service deployment before rerunning the dependent one.
+
+## Health check timeouts
+
+**Symptoms**
+- CI or post-deploy hooks fail with `health check timed out`.
+- Kubernetes readiness probes stay in a failing state; Compose reports unhealthy
+  containers.
+
+**Debugging steps**
+- Verify `health.cmd` is executable inside the container or host.
+- Run the command manually (`docker compose exec <service> /bin/sh -c ...`).
+- Confirm the service listens on the port declared in `APP_PORT` and that TLS
+  expectations match (`scheme` vs actual protocol).
+- Inspect runtime logs for startup failures (systemd `journalctl`, Kubernetes
+  `kubectl logs`).
+
+**Fix**
+- Adjust the health command to wait for application boot (add retries or
+  `sleep`).
+- Ensure the service exposes the declared port and scheme.
+- Increase health timeout thresholds per runtime when necessary (for example
+  `health.timeout` in Compose or `failureThreshold` in Kubernetes).
+
+Documenting the investigation keeps on-call engineers aligned across runtimes.
+Pair this guide with the backup strategy to build a full remediation playbook.


### PR DESCRIPTION
## Summary
- document the supported toolchain versions and fail CI when they drift outside the matrix
- expand HAProxy coverage in the edge guide and add a middleware capability matrix
- add dedicated backup and troubleshooting guides covering Restic workflows and common failure handling

## Testing
- N/A (documentation and CI pipeline updates only)

------
https://chatgpt.com/codex/tasks/task_e_68f406098d90832eb08d6d156bf481d1