### PR TITLE
Improve runtime rendering validation and template hygiene

### DIFF
--- a/roles/common/render_runtime/tasks/main.yml
+++ b/roles/common/render_runtime/tasks/main.yml
@@ -30,6 +30,63 @@
       - runtime in runtime_templates.keys()
     fail_msg: "Runtime {{ runtime }} not supported by service {{ service_id }}"
 
+- name: Validate Kubernetes runtime requirements
+  assert:
+    that:
+      - service_ip is defined
+      - (service_ip | string | length) > 0
+    fail_msg: >-
+      Kubernetes runtime requires service_ip to be explicitly provided for health checks and routing.
+  when: runtime == 'kubernetes'
+
+- name: Validate Proxmox runtime requirements
+  assert:
+    that:
+      - service_ip is defined
+      - service_container is defined
+    fail_msg: >-
+      Proxmox runtime requires service_ip and service_container configuration to be provided.
+  when: runtime == 'proxmox'
+
+- name: Initialize compose service name accumulator
+  set_fact:
+    render_compose_service_names: []
+  when:
+    - runtime in ['docker', 'podman']
+    - services is defined
+    - services | length > 0
+
+- name: Collect compose service names from services list
+  set_fact:
+    render_compose_service_names: >-
+      {{
+        (render_compose_service_names | default([]))
+        + [item.name | default(item.container_name | default(service_name | default(service_id)))]
+      }}
+  loop: "{{ services }}"
+  loop_control:
+    label: "{{ item.name | default(item.container_name | default(service_name | default(service_id))) }}"
+  when:
+    - runtime in ['docker', 'podman']
+    - services is defined
+    - services | length > 0
+
+- name: Fallback compose service name when services list is absent
+  set_fact:
+    render_compose_service_names:
+      - "{{ service_name | default(service_id) }}"
+  when:
+    - runtime in ['docker', 'podman']
+    - (services is not defined) or (services | length == 0)
+
+- name: Detect compose service name collisions
+  assert:
+    that:
+      - (render_compose_service_names | default([])) | length == (render_compose_service_names | default([]) | unique | length)
+    fail_msg: >-
+      Duplicate service_name values detected for {{ runtime }} runtime. service_name values must be unique: {{ render_compose_service_names | default([]) | join(', ') }}.
+  when: runtime in ['docker', 'podman']
+
 - name: Get template path for runtime
   set_fact:
     runtime_template: "{{ runtime_templates[runtime] }}"

--- a/templates/kubernetes.yml.j2
+++ b/templates/kubernetes.yml.j2
@@ -31,6 +31,7 @@
 {% endfor %}
 {% set secret_env = secrets.env if secrets is defined and secrets.env is not none and secrets.env | length > 0 else [] %}
 {% set file_secrets = secrets.files if secrets is defined and secrets.files is not none and secrets.files | length > 0 else [] %}
+{% set inline_env = service_env | default([]) %}
 {% set env_secret_name = svc_name + '-env' %}
 {% set file_secret_name = svc_name + '-files' %}
 {% set health_cmd = health.cmd | default(['true']) %}
@@ -130,7 +131,11 @@ spec:
                 - {{ cap }}
 {% endfor %}
 {% endif %}
+{% set has_secret_env = secret_env | length > 0 %}
+{% set has_inline_env = inline_env | length > 0 %}
+{% if has_secret_env or has_inline_env %}
           env:
+{% if has_secret_env %}
 {% for item in secret_env %}
             - name: {{ item.name }}
               valueFrom:
@@ -138,10 +143,14 @@ spec:
                   name: {{ env_secret_name }}
                   key: {{ item.name }}
 {% endfor %}
-{% for item in service_env | default([]) %}
+{% endif %}
+{% if has_inline_env %}
+{% for item in inline_env %}
             - name: {{ item.name }}
               value: {{ item.value }}
 {% endfor %}
+{% endif %}
+{% endif %}
           ports:
             - containerPort: {{ container_port }}
           volumeMounts:

--- a/templates/proxmox.yml.j2
+++ b/templates/proxmox.yml.j2
@@ -52,6 +52,11 @@
 {% for command in cmd_list %}
   {% set _ = commands_ns.items.append(command) %}
 {% endfor %}
+{% set has_packages = pkg_list | length > 0 %}
+{% set has_config = config_ns.items | length > 0 %}
+{% set has_services = svc_list | length > 0 %}
+{% set has_commands = commands_ns.items | length > 0 %}
+{% set has_setup = has_packages or has_config or has_services or has_commands %}
 {% if proxmox_tmpfs.items and (service_unit_name is defined or service_id is defined) %}
   {% set unit_name = service_unit_name | default(service_id) %}
   {% if unit_name %}
@@ -87,25 +92,36 @@ container:
   features: "keyctl=0"
 {% endif %}
 
+{% if has_setup %}
 setup:
-  packages:{% if pkg_list | length == 0 %} []{% else %}
+{% if has_packages %}
+  packages:
 {% for pkg in pkg_list %}
     - {{ pkg }}
-{% endfor %}{% endif %}
-  config:{% if config_ns.items | length == 0 %} []{% else %}
+{% endfor %}
+{% endif %}
+{% if has_config %}
+  config:
 {% for item in config_ns.items %}
     - path: {{ item.path }}
       content: |
 {{ item.content | indent(8, true) }}{% if item.mode is defined %}
-      mode: {{ item.mode }}{% endif %}
-{% endfor %}{% endif %}
-  services:{% if svc_list | length == 0 %} []{% else %}
+      mode: {{ item.mode }}{% endif %}{% if item.dir_mode is defined %}
+      dir_mode: {{ item.dir_mode }}{% endif %}
+{% endfor %}
+{% endif %}
+{% if has_services %}
+  services:
 {% for svc in svc_list %}
     - name: {{ svc.name }}
       enabled: {{ svc.enabled | default(true) | ternary(true, false) }}
       state: {{ svc.state | default('started') }}
-{% endfor %}{% endif %}
-  commands:{% if commands_ns.items | length == 0 %} []{% else %}
+{% endfor %}
+{% endif %}
+{% if has_commands %}
+  commands:
 {% for cmd in commands_ns.items %}
     - {{ cmd }}
-{% endfor %}{% endif %}
+{% endfor %}
+{% endif %}
+{% endif %}


### PR DESCRIPTION
## Summary
- add runtime-specific validation in the render_runtime role for Kubernetes, Proxmox, and compose runtimes
- ensure the Kubernetes deployment template only emits env sections when values exist
- omit empty structures from the Proxmox template setup block while preserving optional metadata

## Testing
- ansible-playbook tests/render.yml

------
https://chatgpt.com/codex/tasks/task_e_68f4061808fc832eaed1646a7762dd05