### PR TITLE
Add KinD integration tests and strengthen CI protections

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,9 +119,13 @@ service_file = Path(os.environ['SERVICE_FILE'])
 with service_file.open('r', encoding='utf-8') as handle:
     document = yaml.safe_load(handle)
 service_id = document['service_id']
+service_name = document.get('service_name', service_id)
+namespace = document.get('service_namespace', 'default')
 output_dir = Path('/tmp/ansible-runtime') / service_id
 with open(os.environ['GITHUB_OUTPUT'], 'a', encoding='utf-8') as fh:
     fh.write(f"service_id={service_id}\n")
+    fh.write(f"service_name={service_name}\n")
+    fh.write(f"namespace={namespace}\n")
     fh.write(f"runtime_dir={output_dir}\n")
 PY
 
@@ -181,27 +185,184 @@ PY
             ${{ steps.metadata.outputs.runtime_dir }}/podman.yml \
             ${{ steps.metadata.outputs.runtime_dir }}/kubernetes.yml
 
-      - name: Run Conftest policies
+      - name: Run Conftest policies (service definitions)
         run: conftest test ${{ matrix.service_file }} policy
+
+      - name: Verify secret shredding behavior
+        run: ansible-playbook tests/verify_secret_shredding.yml
+
+      - name: Run Conftest policies (rendered Kubernetes manifests)
+        run: conftest test ${{ steps.metadata.outputs.runtime_dir }}/kubernetes.yml policy
 
       - name: Scan referenced container images
         run: |
-          python - <<'PY'
-import json
-import sys
-from pathlib import Path
-import yaml
-
-service_file = Path("${{ matrix.service_file }}")
-document = yaml.safe_load(service_file.read_text())
-image = document.get("service_image")
-if not image:
-    sys.exit(0)
-print(image)
-PY
+          python ci/collect_container_images.py \
+            "${{ matrix.service_file }}" \
+            "${{ steps.metadata.outputs.runtime_dir }}" \
           | while read -r image; do
               trivy image --exit-code 1 --severity CRITICAL --quiet "$image" || exit 1
             done
 
       - name: Cosign policy check
         run: cosign version
+
+  kubernetes-integration:
+    name: "KinD integration (${{ matrix.service_file }})"
+    runs-on: ubuntu-latest
+    needs: lint-and-validate
+    strategy:
+      fail-fast: false
+      matrix:
+        service_file:
+          - tests/sample_service.yml
+          - tests/samples/minimal.yml
+    env:
+      SERVICE_FILE: ${{ matrix.service_file }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@b4ffde65f463d58a31b38cfa6d26b4f752063b9
+
+      - name: Set up Python
+        uses: actions/setup-python@13f3840a65875556b0f1a6d6e5d79d993d3f5a6b
+        with:
+          python-version: '3.11'
+
+      - name: Cache pip
+        uses: actions/cache@13dac90522f915087a5de3c972d4d68512c964b0
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+
+      - name: Install Python dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install --requirement requirements.txt
+
+      - name: Install Ansible collections
+        run: ansible-galaxy collection install -r ci/collections-stable.yml
+
+      - name: Install kubectl
+        run: |
+          version="v1.29.3"
+          curl -fsSL https://dl.k8s.io/release/${version}/bin/linux/amd64/kubectl -o /tmp/kubectl
+          curl -fsSL https://dl.k8s.io/${version}/bin/linux/amd64/kubectl.sha256 -o /tmp/kubectl.sha256
+          echo "$(cat /tmp/kubectl.sha256)  /tmp/kubectl" | sha256sum -c -
+          chmod +x /tmp/kubectl
+          sudo mv /tmp/kubectl /usr/local/bin/kubectl
+
+      - name: Install KinD
+        run: |
+          kind_version="v0.22.0"
+          curl -fsSL https://github.com/kubernetes-sigs/kind/releases/download/${kind_version}/kind-linux-amd64 -o /tmp/kind
+          echo "fa28e8a3d51d38958cd97df1d3b1120686afa6462d39d7496b3fd1d195e27eb0  /tmp/kind" | sha256sum -c -
+          chmod +x /tmp/kind
+          sudo mv /tmp/kind /usr/local/bin/kind
+
+      - name: Determine service metadata
+        id: integration_metadata
+        run: |
+          python - <<'PY'
+import os
+from pathlib import Path
+import yaml
+
+service_file = Path(os.environ['SERVICE_FILE'])
+with service_file.open('r', encoding='utf-8') as handle:
+    document = yaml.safe_load(handle)
+service_id = document['service_id']
+service_name = document.get('service_name', service_id)
+namespace = document.get('service_namespace', 'default')
+output_dir = Path('/tmp/ansible-runtime') / service_id
+with open(os.environ['GITHUB_OUTPUT'], 'a', encoding='utf-8') as fh:
+    fh.write(f"service_id={service_id}\n")
+    fh.write(f"service_name={service_name}\n")
+    fh.write(f"namespace={namespace}\n")
+    fh.write(f"runtime_dir={output_dir}\n")
+PY
+
+      - name: Render Kubernetes manifest
+        run: ansible-playbook tests/render.yml -e runtime=kubernetes -e service_definition_file=${{ matrix.service_file }}
+
+      - name: Create KinD cluster
+        run: kind create cluster --name integration-${{ steps.integration_metadata.outputs.service_id }} --wait 120s
+
+      - name: Apply manifests to KinD
+        env:
+          NAMESPACE: ${{ steps.integration_metadata.outputs.namespace }}
+        run: |
+          kubectl create namespace "$NAMESPACE" --dry-run=client -o yaml | kubectl apply -f -
+          kubectl apply -f "${{ steps.integration_metadata.outputs.runtime_dir }}/kubernetes.yml"
+
+      - name: Wait for deployment readiness
+        env:
+          NAMESPACE: ${{ steps.integration_metadata.outputs.namespace }}
+          SERVICE_NAME: ${{ steps.integration_metadata.outputs.service_name }}
+        run: |
+          kubectl rollout status deployment/$SERVICE_NAME -n $NAMESPACE --timeout=180s
+          kubectl wait --namespace $NAMESPACE --for=condition=Ready pod -l app=$SERVICE_NAME --timeout=180s
+
+      - name: Verify health checks
+        env:
+          NAMESPACE: ${{ steps.integration_metadata.outputs.namespace }}
+          SERVICE_NAME: ${{ steps.integration_metadata.outputs.service_name }}
+        run: |
+          python ci/run_kubernetes_health_checks.py "${{ matrix.service_file }}" "$NAMESPACE" "$SERVICE_NAME"
+
+      - name: Collect diagnostics on failure
+        if: failure()
+        env:
+          NAMESPACE: ${{ steps.integration_metadata.outputs.namespace }}
+          SERVICE_NAME: ${{ steps.integration_metadata.outputs.service_name }}
+        run: |
+          kubectl get all -n $NAMESPACE -o wide || true
+          kubectl describe deployment/$SERVICE_NAME -n $NAMESPACE || true
+          kubectl describe pods -n $NAMESPACE || true
+
+      - name: Tear down KinD cluster
+        if: always()
+        run: kind delete cluster --name integration-${{ steps.integration_metadata.outputs.service_id }} || true
+
+  render-benchmark:
+    name: "Render benchmarks (${{ matrix.service_file }})"
+    runs-on: ubuntu-latest
+    needs: lint-and-validate
+    strategy:
+      fail-fast: false
+      matrix:
+        service_file:
+          - tests/sample_service.yml
+          - tests/samples/full.yml
+          - tests/samples/minimal.yml
+          - tests/samples/with_secrets.yml
+          - tests/samples/with_pvc.yml
+    env:
+      SERVICE_FILE: ${{ matrix.service_file }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@b4ffde65f463d58a31b38cfa6d26b4f752063b9
+
+      - name: Set up Python
+        uses: actions/setup-python@13f3840a65875556b0f1a6d6e5d79d993d3f5a6b
+        with:
+          python-version: '3.11'
+
+      - name: Cache pip
+        uses: actions/cache@13dac90522f915087a5de3c972d4d68512c964b0
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+
+      - name: Install Python dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install --requirement requirements.txt
+
+      - name: Install Ansible collections
+        run: ansible-galaxy collection install -r ci/collections-stable.yml
+
+      - name: Benchmark runtime rendering
+        run: python ci/benchmark_render.py "${{ matrix.service_file }}"

--- a/ci/benchmark_render.py
+++ b/ci/benchmark_render.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Dict, List
+
+import yaml
+
+MAX_RENDER_SECONDS = 15.0
+MAX_MANIFEST_SIZE_BYTES = 512 * 1024
+SUPPORTED_RUNTIMES = ["docker", "podman", "kubernetes", "proxmox", "baremetal"]
+
+
+def load_service_id(service_file: Path) -> str:
+    with service_file.open("r", encoding="utf-8") as handle:
+        document = yaml.safe_load(handle)
+    service_id = document.get("service_id")
+    if not service_id:
+        raise SystemExit(f"service_id missing from {service_file}")
+    return service_id
+
+
+def render_runtime(service_file: Path, runtime: str) -> float:
+    command = [
+        "ansible-playbook",
+        "tests/render.yml",
+        "-e",
+        f"runtime={runtime}",
+        "-e",
+        f"service_definition_file={service_file}",
+    ]
+    start = time.perf_counter()
+    subprocess.run(command, check=True)
+    return time.perf_counter() - start
+
+
+def measure_manifest(runtime_dir: Path, runtime: str) -> int:
+    manifest_path = runtime_dir / f"{runtime}.yml"
+    if not manifest_path.exists():
+        raise SystemExit(f"Expected manifest {manifest_path} was not generated")
+    return manifest_path.stat().st_size
+
+
+def benchmark(service_file: Path) -> Dict[str, Dict[str, float]]:
+    service_id = load_service_id(service_file)
+    runtime_dir = Path("/tmp/ansible-runtime") / service_id
+    results: Dict[str, Dict[str, float]] = {}
+
+    if runtime_dir.exists():
+        shutil.rmtree(runtime_dir)
+    runtime_dir.mkdir(parents=True, exist_ok=True)
+
+    for runtime in SUPPORTED_RUNTIMES:
+        duration = render_runtime(service_file, runtime)
+        size_bytes = measure_manifest(runtime_dir, runtime)
+        results[runtime] = {"duration": duration, "size_bytes": size_bytes}
+    return results
+
+
+def validate(results: Dict[str, Dict[str, float]]) -> List[str]:
+    failures: List[str] = []
+    for runtime, metrics in results.items():
+        if metrics["duration"] > MAX_RENDER_SECONDS:
+            failures.append(
+                f"Rendering {runtime} runtime exceeded {MAX_RENDER_SECONDS}s (actual {metrics['duration']:.2f}s)"
+            )
+        if metrics["size_bytes"] > MAX_MANIFEST_SIZE_BYTES:
+            failures.append(
+                f"Manifest for {runtime} runtime exceeded {MAX_MANIFEST_SIZE_BYTES} bytes (actual {metrics['size_bytes']})"
+            )
+    return failures
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Benchmark runtime rendering speed and size"
+    )
+    parser.add_argument(
+        "service_file", type=Path, help="Path to the service definition file"
+    )
+    args = parser.parse_args()
+
+    results = benchmark(args.service_file)
+    print(json.dumps(results, indent=2))
+
+    failures = validate(results)
+    if failures:
+        for failure in failures:
+            print(failure, file=sys.stderr)
+        raise SystemExit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/ci/collect_container_images.py
+++ b/ci/collect_container_images.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from typing import Iterable, Set
+
+import yaml
+
+
+def _iter_image_values(node: object) -> Iterable[str]:
+    if isinstance(node, dict):
+        for key, value in node.items():
+            if key in {"image", "service_image"} and isinstance(value, str):
+                yield value
+            else:
+                yield from _iter_image_values(value)
+    elif isinstance(node, list):
+        for item in node:
+            yield from _iter_image_values(item)
+
+
+def _collect_from_yaml_file(path: Path) -> Set[str]:
+    images: Set[str] = set()
+    if not path.exists():
+        return images
+
+    try:
+        documents = list(yaml.safe_load_all(path.read_text()))
+    except yaml.YAMLError as exc:  # pragma: no cover - validation happens in CI
+        raise SystemExit(f"Failed to parse YAML from {path}: {exc}") from exc
+
+    for doc in documents:
+        if doc is None:
+            continue
+        for image in _iter_image_values(doc):
+            images.add(image)
+    return images
+
+
+def _collect_from_quadlet(path: Path) -> Set[str]:
+    images: Set[str] = set()
+    if not path.exists():
+        return images
+
+    for line in path.read_text().splitlines():
+        if line.startswith("Image="):
+            _, _, value = line.partition("=")
+            if value:
+                images.add(value.strip())
+    return images
+
+
+def collect_images(service_file: Path, runtime_dir: Path) -> Set[str]:
+    service_doc = yaml.safe_load(service_file.read_text())
+    images = set(_iter_image_values(service_doc))
+
+    images.update(_collect_from_yaml_file(runtime_dir / "docker.yml"))
+    images.update(_collect_from_yaml_file(runtime_dir / "kubernetes.yml"))
+    images.update(_collect_from_quadlet(runtime_dir / "podman.yml"))
+
+    return {image for image in images if image}
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Collect container images for scanning"
+    )
+    parser.add_argument(
+        "service_file", type=Path, help="Path to the service definition"
+    )
+    parser.add_argument(
+        "runtime_dir", type=Path, help="Directory containing rendered runtime manifests"
+    )
+    args = parser.parse_args()
+
+    images = sorted(collect_images(args.service_file, args.runtime_dir))
+    if not images:
+        return
+
+    for image in images:
+        print(image)
+
+
+if __name__ == "__main__":
+    main()

--- a/ci/run_kubernetes_health_checks.py
+++ b/ci/run_kubernetes_health_checks.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+from pathlib import Path
+from typing import List
+
+import yaml
+
+
+def load_health_command(service_file: Path) -> List[str]:
+    document = yaml.safe_load(service_file.read_text())
+    health = document.get("health") or {}
+    command = health.get("cmd") or ["true"]
+    if not isinstance(command, list):
+        raise SystemExit("health.cmd must be an array of command arguments")
+    return [str(arg) for arg in command]
+
+
+def ensure_health(namespace: str, app_name: str, command: List[str]) -> None:
+    get_pods = subprocess.run(
+        [
+            "kubectl",
+            "get",
+            "pods",
+            "-n",
+            namespace,
+            "-l",
+            f"app={app_name}",
+            "-o",
+            "json",
+        ],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    payload = json.loads(get_pods.stdout)
+    items = payload.get("items", [])
+    if not items:
+        raise SystemExit(f"No pods found for app={app_name} in namespace {namespace}")
+
+    pod_name = items[0]["metadata"]["name"]
+    subprocess.run(
+        ["kubectl", "exec", "-n", namespace, pod_name, "--", *command],
+        check=True,
+    )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Run workload health checks inside Kubernetes pods"
+    )
+    parser.add_argument("service_file", type=Path, help="Service definition file")
+    parser.add_argument("namespace", help="Kubernetes namespace")
+    parser.add_argument("app_name", help="App label and deployment name")
+    args = parser.parse_args()
+
+    command = load_health_command(args.service_file)
+    ensure_health(args.namespace, args.app_name, command)
+
+
+if __name__ == "__main__":
+    main()

--- a/policy/kubernetes.rego
+++ b/policy/kubernetes.rego
@@ -1,0 +1,29 @@
+package shma.kubernetes
+
+resources[resource] {
+  type_name(input) == "array"
+  resource := input[_]
+}
+
+resources[resource] {
+  type_name(input) != "array"
+  resource := input
+}
+
+deprecated_apis := {
+  "extensions/v1beta1",
+  "apps/v1beta1",
+  "apps/v1beta2",
+  "networking.k8s.io/v1beta1",
+  "policy/v1beta1",
+}
+
+deny[msg] {
+  resource := resources[_]
+  api := resource.apiVersion
+  api != null
+  api := deprecated_apis[_]
+  name := resource.metadata.name
+  kind := resource.kind
+  msg := sprintf("%s/%s uses deprecated apiVersion %s", [kind, name, api])
+}

--- a/policy/service.rego
+++ b/policy/service.rego
@@ -29,3 +29,75 @@ deny[msg] {
   not input.service_namespace
   msg := "service_namespace must be defined when secrets are present"
 }
+
+# Enforce basic complexity requirements for inline secret values.
+deny[msg] {
+  secret := input.secrets.env[_]
+  value := secret.value
+  not secret_complex(value)
+  msg := sprintf(
+    "secret %q must be at least 16 characters and include multiple character classes",
+    [secret.name],
+  )
+}
+
+secret_complex(value) {
+  secret_length_ok(value)
+  count(secret_character_classes(value)) >= 2
+}
+
+secret_length_ok(value) {
+  re_match("^.{16,}$", value)
+}
+
+secret_character_classes(value)[class] {
+  re_match("[a-z]", value)
+  class := "lower"
+}
+
+secret_character_classes(value)[class] {
+  re_match("[A-Z]", value)
+  class := "upper"
+}
+
+secret_character_classes(value)[class] {
+  re_match("[0-9]", value)
+  class := "digit"
+}
+
+secret_character_classes(value)[class] {
+  re_match("[^A-Za-z0-9]", value)
+  class := "special"
+}
+
+# Resource requests must stay within supported bounds.
+deny[msg] {
+  memory := input.service_resources.memory_mb
+  not within_range(memory, 64, 65536)
+  msg := sprintf("service_resources.memory_mb %d must be between 64 and 65536", [memory])
+}
+
+deny[msg] {
+  cpu := input.service_resources.cpu_cores
+  not within_range(cpu, 0.1, 64)
+  msg := sprintf("service_resources.cpu_cores %v must be between 0.1 and 64", [cpu])
+}
+
+within_range(value, min, max) {
+  value >= min
+  value <= max
+}
+
+# Disallow privileged host port exposure.
+deny[msg] {
+  port := input.service_ports[_]
+  port.published < 1024
+  msg := sprintf("service port %v publishes privileged host port %v", [port.target, port.published])
+}
+
+deny[msg] {
+  port := input.service_ports[_]
+  port.host_ip
+  port.host_ip == "0.0.0.0"
+  msg := sprintf("service port %v exposes 0.0.0.0; use a specific host_ip", [port.target])
+}

--- a/roles/common/apply_runtime/tasks/docker.yml
+++ b/roles/common/apply_runtime/tasks/docker.yml
@@ -41,30 +41,14 @@
     state: present
     pull: always
 
-- name: Remove Compose secret environment file after apply
-  file:
-    path: "{{ compose_secret_env_path }}"
-    state: absent
-  when:
-    - compose_secret_shred | bool
-    - compose_secret_env | length > 0
-
-- name: Remove Compose secret files after apply
-  file:
-    path: "{{ runtime_output_dir }}/secrets/{{ item.name }}"
-    state: absent
-  loop: "{{ compose_secret_files }}"
-  when:
-    - compose_secret_shred | bool
-    - compose_secret_files | length > 0
-
-- name: Remove Compose secret directory after apply
-  file:
-    path: "{{ runtime_output_dir }}/secrets"
-    state: absent
-  when:
-    - compose_secret_shred | bool
-    - compose_secret_files | length > 0
+- name: Remove Compose secrets after apply
+  ansible.builtin.include_tasks: secret_cleanup.yml
+  vars:
+    cleanup_secret_env_path: "{{ compose_secret_env_path }}"
+    cleanup_secret_env: "{{ compose_secret_env }}"
+    cleanup_secret_files: "{{ compose_secret_files }}"
+    cleanup_secret_dir: "{{ runtime_output_dir }}/secrets"
+    cleanup_secret_shred: "{{ compose_secret_shred }}"
 
 - name: Set service IP for health checks
   set_fact:

--- a/roles/common/apply_runtime/tasks/podman.yml
+++ b/roles/common/apply_runtime/tasks/podman.yml
@@ -78,34 +78,15 @@
     state: started
     scope: "{{ quadlet_effective_scope }}"
 
-- name: Remove Quadlet environment file after apply
-  file:
-    path: "{{ quadlet_env_path }}"
-    state: absent
-  when:
-    - quadlet_secret_shred | bool
-    - quadlet_secret_env | length > 0
-  become: {{ (quadlet_effective_scope == 'system') | bool }}
-
-- name: Remove Quadlet secret files after apply
-  file:
-    path: "{{ quadlet_secret_dir }}/{{ item.name }}"
-    state: absent
-  loop: "{{ quadlet_secret_files }}"
-  when:
-    - quadlet_secret_shred | bool
-    - quadlet_secret_files | length > 0
-  no_log: true
-  become: {{ (quadlet_effective_scope == 'system') | bool }}
-
-- name: Remove Quadlet secret directory after apply
-  file:
-    path: "{{ quadlet_secret_dir }}"
-    state: absent
-  when:
-    - quadlet_secret_shred | bool
-    - quadlet_secret_files | length > 0
-  become: {{ (quadlet_effective_scope == 'system') | bool }}
+- name: Remove Quadlet secrets after apply
+  ansible.builtin.include_tasks: secret_cleanup.yml
+  vars:
+    cleanup_secret_env_path: "{{ quadlet_env_path }}"
+    cleanup_secret_env: "{{ quadlet_secret_env }}"
+    cleanup_secret_files: "{{ quadlet_secret_files }}"
+    cleanup_secret_dir: "{{ quadlet_secret_dir }}"
+    cleanup_secret_shred: "{{ quadlet_secret_shred }}"
+    cleanup_become: {{ (quadlet_effective_scope == 'system') | bool }}
 
 - name: Set service IP for health checks
   set_fact:

--- a/roles/common/apply_runtime/tasks/secret_cleanup.yml
+++ b/roles/common/apply_runtime/tasks/secret_cleanup.yml
@@ -1,0 +1,30 @@
+---
+- name: Remove secret environment file after apply
+  ansible.builtin.file:
+    path: "{{ cleanup_secret_env_path }}"
+    state: absent
+  when:
+    - cleanup_secret_shred | default(true) | bool
+    - cleanup_secret_env | default([]) | length > 0
+  become: "{{ cleanup_become | default(false) }}"
+  no_log: "{{ cleanup_env_no_log | default(false) }}"
+
+- name: Remove secret files after apply
+  ansible.builtin.file:
+    path: "{{ cleanup_secret_dir }}/{{ item.name }}"
+    state: absent
+  loop: "{{ cleanup_secret_files | default([]) }}"
+  when:
+    - cleanup_secret_shred | default(true) | bool
+    - cleanup_secret_files | default([]) | length > 0
+  no_log: true
+  become: "{{ cleanup_become | default(false) }}"
+
+- name: Remove secret directory after apply
+  ansible.builtin.file:
+    path: "{{ cleanup_secret_dir }}"
+    state: absent
+  when:
+    - cleanup_secret_shred | default(true) | bool
+    - cleanup_secret_files | default([]) | length > 0
+  become: "{{ cleanup_become | default(false) }}"

--- a/tests/verify_secret_shredding.yml
+++ b/tests/verify_secret_shredding.yml
@@ -1,0 +1,86 @@
+---
+- name: Verify secret shredding cleanup
+  hosts: localhost
+  gather_facts: false
+  connection: local
+  vars:
+    shred_tempdir: null
+    secret_env_content:
+      - name: API_TOKEN
+        value: 8d1d12a2b8a4d5f6c7e8f9a0b1c2d3e4
+    secret_file_entries:
+      - name: tls-cert
+        value: "-----BEGIN CERTIFICATE-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAvUlCExampleCertificate\n-----END CERTIFICATE-----"
+        target: /etc/service/certs/tls.crt
+  tasks:
+    - name: Create temporary directory for shredding test
+      ansible.builtin.tempfile:
+        state: directory
+        prefix: secret-shred-
+      register: shred_tempdir_result
+
+    - name: Set shredding paths
+      ansible.builtin.set_fact:
+        shred_tempdir: "{{ shred_tempdir_result.path }}"
+        secret_env_path: "{{ shred_tempdir_result.path }}/service.env"
+        secret_dir: "{{ shred_tempdir_result.path }}/secrets"
+
+    - name: Write environment secret file
+      ansible.builtin.copy:
+        dest: "{{ secret_env_path }}"
+        mode: '0600'
+        content: |-
+          {% for item in secret_env_content %}
+          {{ item.name }}={{ item.value }}
+          {% endfor %}
+
+    - name: Ensure secret directory exists
+      ansible.builtin.file:
+        path: "{{ secret_dir }}"
+        state: directory
+        mode: '0700'
+
+    - name: Write file-based secrets
+      ansible.builtin.copy:
+        dest: "{{ secret_dir }}/{{ item.name }}"
+        mode: '0400'
+        content: "{{ item.value }}"
+      loop: "{{ secret_file_entries }}"
+
+    - name: Include shared secret cleanup tasks
+      ansible.builtin.include_tasks: "{{ playbook_dir }}/../roles/common/apply_runtime/tasks/secret_cleanup.yml"
+      vars:
+        cleanup_secret_env_path: "{{ secret_env_path }}"
+        cleanup_secret_env: "{{ secret_env_content }}"
+        cleanup_secret_files: "{{ secret_file_entries }}"
+        cleanup_secret_dir: "{{ secret_dir }}"
+        cleanup_secret_shred: true
+
+    - name: Assert environment secret file removed
+      ansible.builtin.stat:
+        path: "{{ secret_env_path }}"
+      register: env_stat
+
+    - name: Assert file secret removed
+      ansible.builtin.stat:
+        path: "{{ secret_dir }}/{{ secret_file_entries[0].name }}"
+      register: file_stat
+
+    - name: Assert secret directory removed
+      ansible.builtin.stat:
+        path: "{{ secret_dir }}"
+      register: dir_stat
+
+    - name: Validate shredding results
+      ansible.builtin.assert:
+        that:
+          - not env_stat.stat.exists
+          - not file_stat.stat.exists
+          - not dir_stat.stat.exists
+        fail_msg: "Secret artifacts were not properly shredded"
+
+    - name: Remove temporary directory
+      ansible.builtin.file:
+        path: "{{ shred_tempdir }}"
+        state: absent
+      when: shred_tempdir is not none


### PR DESCRIPTION
## Summary
- add a KinD-backed integration workflow that deploys rendered manifests and runs health checks
- extend Trivy scanning to cover all rendered images and add benchmarks plus secret shredding validation to CI
- expand Conftest policies for secrets, resources, ports, and Kubernetes API usage while sharing cleanup logic

## Testing
- ansible-playbook tests/verify_secret_shredding.yml

------
https://chatgpt.com/codex/tasks/task_e_68f4060c762c832ebf24eac71a899dd2