### PR TITLE
Harden runtime security defaults across adapters

### DIFF
--- a/docs/baremetal.md
+++ b/docs/baremetal.md
@@ -8,6 +8,7 @@ Deploy services directly on bare-metal or virtual machines with idempotent confi
 - Configuration files defined in the service contract render exactly once and trigger handlers when changed.
 - Generated units inherit defaults from `templates/baremetal.yml.j2`, keeping runtime-agnostic settings consistent.
 - `mounts.ephemeral_mounts` entries render `TemporaryFileSystem=` directives so only the declared paths stay writable at runtime.
+- systemd units enable `PrivateTmp=yes`, `ProtectSystem=strict`, and `ProtectHome=yes` by default (unless overridden via `service_security`) to harden the host.
 
 ## Prerequisites
 

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -10,7 +10,7 @@ Deploy services using Docker Compose with secret-aware environment files and Com
 - Health probes come directly from `health.cmd` ensuring parity with other runtimes.
 - Host bind mounts are first-class: specify `service_volumes.host_path` to keep container filesystems disposable while state persists on the host.
 - Ephemeral tmpfs mounts defined under `mounts.ephemeral_mounts` render via Compose `tmpfs` entries so only declared paths remain writable.
-- Containers default to running as UID/GID `65532`, drop all capabilities, run as read-only, and set `no-new-privileges`. Override with `service_security` when a workload needs explicit grants.
+- Containers default to running as UID/GID `65532`, drop all capabilities, run as read-only, enforce `no-new-privileges`, and attach the Docker `apparmor=docker-default` profile. Override with `service_security` when a workload needs explicit grants or to supply a different AppArmor profile.
 
 ## Prerequisites
 
@@ -41,6 +41,7 @@ services:
       - ALL
     security_opt:
       - no-new-privileges:true
+      - apparmor=docker-default
     env_file:
       - ./sample-service.env
     environment:

--- a/docs/podman.md
+++ b/docs/podman.md
@@ -10,7 +10,7 @@ Deploy services using Podman Quadlets with environment files, optional user scop
 - Host policy defaults to rejecting unsigned/unknown registries and the local Docker engine, keeping pulls scoped to approved sources.
 - `service_volumes.host_path` entries render as direct bind mounts so containers remain ephemeral while state lives on the host.
 - `service_image` entries should be digest-pinned; combine with `quadlet_auto_update: none` to ensure only vetted images run.
-- `mounts.ephemeral_mounts` entries become `Tmpfs=` declarations so containers only write to explicitly allowed paths.
+- `mounts.ephemeral_mounts` entries become `Tmpfs=` declarations hardened with `nosuid`, `nodev`, and `noexec` so containers only write to explicitly allowed paths.
 - Containers default to `User=65532:65532`, `ReadOnly=true`, `NoNewPrivileges=true`, `DropCapability=ALL`, and an empty `CapabilityBoundingSet`. Override with `service_security` only when workloads need extra permissions.
 
 ## Requirements
@@ -48,8 +48,8 @@ Environment=APP_MODE=production
 Environment=APP_FEATURE_FLAG=true
 EnvironmentFile=/etc/containers/systemd/sample-service.env
 Volume=/srv/sample-service/config:/etc/sample-service:Z
-Tmpfs=/run/sample-service:size=64Mi,mode=0755
-Tmpfs=/tmp/sample-service:size=64Mi
+Tmpfs=/run/sample-service:nosuid,nodev,noexec,size=64Mi,mode=0755
+Tmpfs=/tmp/sample-service:nosuid,nodev,noexec,size=64Mi
 PublishPort=192.0.2.50:8080:8080
 Volume=/etc/containers/systemd/secrets/tls-cert:/etc/sample-service/certs/tls.crt:ro,Z
 HealthCmd=/bin/sh -c exit 0

--- a/docs/proxmox.md
+++ b/docs/proxmox.md
@@ -6,6 +6,7 @@ Deploy services as LXC containers on Proxmox VE with predictable networking and 
 
 - Templates emit `container_ip`, removing brittle IP parsing in Ansible tasks.
 - LXC features derive exclusively from the service contract. Nested container flags such as `nesting=1,keyctl=1` appear only when you explicitly set `service_container.features`.
+- Feature declarations are validated against a whitelist (`nesting`, `keyctl`, `fuse`, `mount`) so typos fail fast instead of reaching Proxmox.
 - Ansible waits for SSH on `container_ip` (120 seconds) before running delegate tasks.
 - Package installation inside the container uses non-interactive APT and applies any rendered configuration or command hooks.
 - `mounts.ephemeral_mounts` entries render as systemd drop-ins (`TemporaryFileSystem=`) inside the guest so writable areas stay tmpfs backed.

--- a/schemas/service.schema.yml
+++ b/schemas/service.schema.yml
@@ -323,6 +323,16 @@ properties:
         type: array
         items:
           type: string
+      apparmor_profile:
+        type: string
+      private_tmp:
+        type: boolean
+      protect_system:
+        type: string
+      protect_home:
+        oneOf:
+          - type: boolean
+          - type: string
   kubernetes:
     type: object
     properties:

--- a/templates/baremetal.yml.j2
+++ b/templates/baremetal.yml.j2
@@ -3,6 +3,7 @@
 {% set after = unit.after | default(['network.target']) %}
 {% set service_section = unit.service | default({'Type': 'simple', 'ExecStart': '/usr/bin/true'}) %}
 {% set install_targets = unit.install_wanted_by | default(['multi-user.target']) %}
+{% set security = service_security | default({}) %}
 {% set mounts_config = mounts | default({}) %}
 {% set ephemeral_mounts = mounts_config.ephemeral_mounts | default([]) %}
 {% set default_apply_targets = ['docker', 'podman', 'kubernetes', 'proxmox', 'baremetal'] %}
@@ -16,6 +17,26 @@
     {% set _ = baremetal_tmpfs.items.append({'path': mount.path, 'options': options}) %}
   {% endif %}
 {% endfor %}
+{% set read_only_root = security.read_only_root_filesystem if security.read_only_root_filesystem is defined else true %}
+{% set private_tmp_default = security.private_tmp if security.private_tmp is defined else true %}
+{% set protect_system_default = security.protect_system if security.protect_system is defined else (read_only_root | ternary('strict', 'full')) %}
+{% set protect_home_default = security.protect_home if security.protect_home is defined else 'yes' %}
+{% if protect_home_default is boolean %}
+  {% set protect_home_value = protect_home_default | ternary('yes', 'no') %}
+{% else %}
+  {% set protect_home_value = protect_home_default %}
+{% endif %}
+{% if private_tmp_default is boolean %}
+  {% set private_tmp_value = private_tmp_default | ternary('yes', 'no') %}
+{% else %}
+  {% set private_tmp_value = private_tmp_default %}
+{% endif %}
+{% if protect_system_default is boolean %}
+  {% set protect_system_value = protect_system_default | ternary('strict', 'no') %}
+{% else %}
+  {% set protect_system_value = protect_system_default %}
+{% endif %}
+
 [Unit]
 Description={{ description }}
 {% for dependency in after %}
@@ -26,6 +47,15 @@ After={{ dependency }}
 {% for key, value in service_section.items() %}
 {{ key }}={{ value }}
 {% endfor %}
+{% if 'PrivateTmp' not in service_section %}
+PrivateTmp={{ private_tmp_value }}
+{% endif %}
+{% if 'ProtectSystem' not in service_section %}
+ProtectSystem={{ protect_system_value }}
+{% endif %}
+{% if 'ProtectHome' not in service_section %}
+ProtectHome={{ protect_home_value }}
+{% endif %}
 {% if baremetal_tmpfs.items %}
 {% for mount in baremetal_tmpfs.items %}
 TemporaryFileSystem={{ mount.path }}{% if mount.options %}:{{ mount.options | join(',') }}{% endif %}

--- a/templates/docker.yml.j2
+++ b/templates/docker.yml.j2
@@ -9,6 +9,7 @@
 {%- set drop_caps_default = security.capabilities_drop | default(['ALL']) %}
 {%- if drop_caps_default is string %}{%- set drop_caps_default = [drop_caps_default] %}{%- endif %}
 {%- set no_new_privs = security.no_new_privileges if security.no_new_privileges is defined else true %}
+{%- set default_apparmor = security.apparmor_profile if security.apparmor_profile is defined else 'docker-default' %}
 {%- set docker_tmpfs = namespace(items=[]) %}
 {%- for mount in ephemeral_mounts %}
   {%- set apply_targets = mount.apply_to | default(default_apply_targets) %}
@@ -48,6 +49,19 @@ services:
   {%- if no_new_privs %}
     {%- if 'no-new-privileges:true' not in svc_security_opt.items %}
       {%- set _ = svc_security_opt.items.append('no-new-privileges:true') %}
+    {%- endif %}
+  {%- endif %}
+  {%- set has_apparmor = false %}
+  {%- for opt in svc_security_opt.items %}
+    {%- if opt is string and opt.startswith('apparmor=') %}
+      {%- set has_apparmor = true %}
+    {%- endif %}
+  {%- endfor %}
+  {%- set svc_apparmor = svc.apparmor_profile if svc.apparmor_profile is defined else default_apparmor %}
+  {%- if svc_apparmor is not none and (svc_apparmor | string) | length > 0 %}
+    {%- set apparmor_opt = 'apparmor=' ~ svc_apparmor %}
+    {%- if not has_apparmor and apparmor_opt not in svc_security_opt.items %}
+      {%- set _ = svc_security_opt.items.append(apparmor_opt) %}
     {%- endif %}
   {%- endif %}
   {%- set svc_tmpfs = namespace(items=[]) %}

--- a/templates/kubernetes.yml.j2
+++ b/templates/kubernetes.yml.j2
@@ -114,6 +114,8 @@ spec:
       labels:
         app: {{ svc_name }}
     spec:
+      securityContext:
+        readOnlyRootFilesystem: {{ read_only_root | ternary(true, false) }}
       containers:
         - name: {{ svc_name }}
           image: {{ service_image }}

--- a/templates/podman.yml.j2
+++ b/templates/podman.yml.j2
@@ -11,11 +11,15 @@
 {% set no_new_privs = security.no_new_privileges if security.no_new_privileges is defined else true %}
 {% set bounding_set = security.capability_bounding_set if security.capability_bounding_set is defined else [] %}
 {% if bounding_set is string %}{% set bounding_set = [bounding_set] %}{% endif %}
+{% set tmpfs_hardening_flags = ['nosuid', 'nodev', 'noexec'] %}
 {% set podman_tmpfs = namespace(items=[]) %}
 {% for mount in ephemeral_mounts %}
   {% set apply_targets = mount.apply_to | default(default_apply_targets) %}
   {% if 'podman' in apply_targets %}
     {% set options = [] %}
+    {% for flag in tmpfs_hardening_flags %}
+      {% if flag not in options %}{% set _ = options.append(flag) %}{% endif %}
+    {% endfor %}
     {% if mount.size is defined %}{% set _ = options.append('size=' ~ mount.size) %}{% endif %}
     {% if mount.mode is defined %}{% set _ = options.append('mode=' ~ mount.mode) %}{% endif %}
     {% set entry = mount.path %}

--- a/templates/proxmox.yml.j2
+++ b/templates/proxmox.yml.j2
@@ -30,16 +30,51 @@
     {% set _ = pkg_names.items.append(pkg_name | lower) %}
   {% endif %}
 {% endfor %}
+{% set allowed_lxc_features = ['nesting', 'keyctl', 'fuse', 'mount'] %}
 {% set feature_ns = namespace(value=None) %}
 {% if container.features is defined %}
-  {% if container.features %}
-    {% if container.features is string %}
-      {% set feature_ns.value = container.features %}
-    {% elif container.features is sequence %}
-      {% set feature_ns.value = container.features | join(',') %}
-    {% else %}
-      {% set feature_ns.value = container.features | string %}
+  {% set raw_features = [] %}
+  {% if container.features is string %}
+    {% set raw_features = (container.features | string) | split(',') %}
+  {% elif container.features is sequence %}
+    {% set raw_features = container.features %}
+  {% elif container.features %}
+    {% set raw_features = [container.features] %}
+  {% endif %}
+  {% set validated = namespace(items=[]) %}
+  {% set invalid = namespace(items=[]) %}
+  {% for feature in raw_features %}
+    {% set feature_str = feature | string %}
+    {% set trimmed = feature_str | trim %}
+    {% if trimmed %}
+      {% set parts = trimmed | split('=') %}
+      {% set name = parts[0] | trim %}
+      {% if name in allowed_lxc_features %}
+        {% set value_parts = parts[1:] %}
+        {% set value = value_parts | join('=') %}
+        {% if value | length > 0 %}
+          {% set normalized = name ~ '=' ~ value | trim %}
+        {% else %}
+          {% set normalized = name ~ '=1' %}
+        {% endif %}
+        {% if normalized not in validated.items %}
+          {% set _ = validated.items.append(normalized) %}
+        {% endif %}
+      {% else %}
+        {% if name %}
+          {% set _ = invalid.items.append(name) %}
+        {% else %}
+          {% set _ = invalid.items.append(trimmed) %}
+        {% endif %}
+      {% endif %}
     {% endif %}
+  {% endfor %}
+  {% if invalid.items %}
+    {% set invalid_message = 'Unknown Proxmox LXC feature(s): ' ~ (invalid.items | unique | join(', ')) %}
+    {{ lookup('pipe', 'python3 -c "import sys; sys.stderr.write(\"' ~ (invalid_message | replace('"', '\\"')) ~ '\n\"); sys.exit(1)"') }}
+  {% endif %}
+  {% if validated.items %}
+    {% set feature_ns.value = validated.items | join(',') %}
   {% else %}
     {% set feature_ns.value = '' %}
   {% endif %}


### PR DESCRIPTION
## Summary
- default Docker services to include an AppArmor profile by default while allowing service_security overrides
- harden Podman tmpfs mounts and baremetal systemd units, wiring new service_security knobs into the schema and docs
- validate Proxmox LXC feature flags and add a pod-level readOnlyRootFilesystem default for Kubernetes manifests

## Testing
- ansible-playbook tests/render.yml
- ansible-playbook tests/render.yml -e runtime=podman
- ansible-playbook tests/render.yml -e runtime=proxmox
- ansible-playbook tests/render.yml -e runtime=baremetal
- ansible-playbook tests/render.yml -e runtime=kubernetes *(fails: existing templating error `'AnsibleUnicode' object is not callable`)*

------
https://chatgpt.com/codex/tasks/task_e_68f406241394832e93cb06fa4e0364f3