### PR TITLE
Remove legacy service_volume key from service contracts

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## Unreleased
+### Removed
+- Removed support for the legacy `service_volume` key from service definitions. Inventories must use the `service_volumes` array instead. Validation now surfaces a warning and failure when the deprecated key is detected.
+
+### Documentation
+- Updated infrastructure README to reflect the removal timeline for `service_volume`.

--- a/docs/README.md
+++ b/docs/README.md
@@ -97,7 +97,7 @@ secrets:
       value: "{{ sample_service_tls_cert }}"
 ```
 
-> **Note:** Always declare host mounts with `service_volumes` (plural). The legacy `service_volume` key is deprecated and retained only for backward compatibility with older inventories.
+> **Note:** Always declare host mounts with `service_volumes` (plural). The legacy `service_volume` key has been removed; migrate older inventories to the plural form before running validation.
 
 Downstream applications consume these exports by resolving them through a dependency registry shared between repositories. Provide the registry as a list of known dependencies either inline (`dependency_registry`) or via `dependency_registry_file`:
 

--- a/roles/common/validate_schema/tasks/main.yml
+++ b/roles/common/validate_schema/tasks/main.yml
@@ -16,6 +16,24 @@
       - runtime_templates is defined
     fail_msg: "Service {{ service_id | default('unknown') }} is missing required contract fields"
 
+- name: Detect legacy service_volume usage
+  when: service_volume is defined
+  block:
+    - name: Warn about removed service_volume key
+      debug:
+        msg: >-
+          Service {{ service_id | default('unknown') }} still defines the legacy
+          service_volume key. Support for service_volume was removed; rename the
+          definition to service_volumes (array) before continuing.
+        warn: true
+
+    - name: Fail when legacy service_volume is present
+      fail:
+        msg: >-
+          Service {{ service_id | default('unknown') }} uses the removed
+          service_volume key. Rename it to service_volumes (array) and re-run
+          validation.
+
 - name: Initialize dependency registry sources
   set_fact:
     dependency_registry_sources: []

--- a/schemas/service.schema.yml
+++ b/schemas/service.schema.yml
@@ -190,8 +190,6 @@ properties:
   needs_container_runtime:
     type: boolean
 
-  service_volume:
-    type: object
   version:
     type: string
   requires:

--- a/templates/kubernetes.yml.j2
+++ b/templates/kubernetes.yml.j2
@@ -46,7 +46,7 @@
 {% set memory_request = resources.memory_mb | default(256) %}
 {% set cpu_cores = resources.cpu_cores | default(1) %}
 {% set connections_per_second = resources.connections_per_second if resources.connections_per_second is defined else None %}
-{% set volume_config = service_volume | default(service_volumes[0] if service_volumes is defined and service_volumes | length > 0 else None) %}
+{% set volume_config = service_volumes[0] if service_volumes is defined and service_volumes | length > 0 else None %}
 {% set use_host_path = volume_config is mapping and volume_config.host_path is defined %}
 {% set host_path = volume_config.host_path if use_host_path else None %}
 {% set host_path_type = volume_config.host_path_type | default('DirectoryOrCreate') if use_host_path else 'DirectoryOrCreate' %}


### PR DESCRIPTION
## Summary
- drop the unused `service_volume` schema entry and associated template fallback
- add validation that warns and fails when inventories still define `service_volume`
- document the removal in the changelog and README

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f40ed6f014832ebdbb87830e5d5408