### PR TITLE
Add Quadlet runtime parity tests and strengthen secret scanning

### DIFF
--- a/ci/assert_no_inline_secrets.py
+++ b/ci/assert_no_inline_secrets.py
@@ -18,32 +18,75 @@ def gather_secret_values(service: dict) -> set[str]:
     secrets = set()
     secret_block = service.get("secrets", {})
 
+    def _collect_candidates(item: dict) -> set[str]:
+        candidates: set[str] = set()
+        for field in ("value", "content"):
+            value = item.get(field)
+            if value:
+                candidates.add(str(value))
+        return candidates
+
     for item in secret_block.get("env", []) or []:
-        value = item.get("value")
-        if value:
-            secrets.add(str(value))
+        secrets.update(_collect_candidates(item))
 
     for item in secret_block.get("files", []) or []:
-        value = item.get("value")
-        if value:
-            secrets.add(str(value))
+        secrets.update(_collect_candidates(item))
 
     return secrets
 
 
+def _extract_quadlet_entries(content: str) -> tuple[set[str], set[str]]:
+    entries: set[str] = set()
+    paths: set[str] = set()
+
+    for line in content.splitlines():
+        key, _, value = line.partition("=")
+        if not value:
+            continue
+        key = key.strip()
+        value = value.strip()
+        if key in {"Environment", "EnvironmentFile", "Volume"}:
+            if value:
+                entries.add(value)
+        if key in {"EnvironmentFile", "Volume"}:
+            host_path, _, _ = value.partition(":")
+            host_path = host_path.strip()
+            if host_path:
+                paths.add(host_path)
+
+    return entries, paths
+
+
 def check_manifest(manifest_path: Path, secrets: set[str]) -> list[str]:
     content = manifest_path.read_text()
-    found = []
+    found: set[str] = set()
+
     for secret in secrets:
         if secret and secret in content:
-            found.append(secret)
-    return found
+            found.add(secret)
+
+    if "[Container]" in content and "[Service]" in content:
+        entries, paths = _extract_quadlet_entries(content)
+        for candidate in entries.union(paths):
+            for secret in secrets:
+                if secret and secret in candidate:
+                    found.add(secret)
+
+    return sorted(found)
 
 
 def build_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(description="Ensure rendered manifests do not contain inline secrets")
-    parser.add_argument("service_definition", type=Path, help="Service definition file used during rendering")
-    parser.add_argument("manifest", nargs="+", type=Path, help="Manifest files to inspect")
+    parser = argparse.ArgumentParser(
+        description="Ensure rendered manifests do not contain inline secrets"
+    )
+    parser.add_argument(
+        "service_definition",
+        type=Path,
+        help="Service definition file used during rendering",
+    )
+    parser.add_argument(
+        "manifest", nargs="+", type=Path, help="Manifest files to inspect"
+    )
     return parser
 
 

--- a/templates/docker.yml.j2
+++ b/templates/docker.yml.j2
@@ -139,34 +139,31 @@ services:
 {% if connections_per_second and svc.name == primary_service_name %}
   {% set inline_env = inline_env + [{'name': 'CONNECTIONS_PER_SECOND', 'value': connections_per_second | string}] %}
 {% endif %}
-{% if inline_env %}
+  {% for item in inline_env %}
+    {% if item.name not in environment_ns.names %}
+      {% set _ = environment_ns.items.append({'name': item.name, 'value': item.value}) %}
+      {% set _ = environment_ns.names.append(item.name) %}
+    {% endif %}
+  {% endfor %}
+  {% if secrets is defined and secrets.rotation_timestamp is defined and secrets.rotation_timestamp is not none %}
+    {% if 'SHMA_SECRETS_ROTATION' not in environment_ns.names %}
+      {% set _ = environment_ns.items.append({'name': 'SHMA_SECRETS_ROTATION', 'value': secrets.rotation_timestamp}) %}
+      {% set _ = environment_ns.names.append('SHMA_SECRETS_ROTATION') %}
+    {% endif %}
+  {% endif %}
+  {% for secret_item in svc_secret_env %}
+    {% if secret_item.name not in environment_ns.names %}
+      {% set _ = environment_ns.items.append({'name': secret_item.name, 'value': '${' ~ secret_item.name ~ '}'}) %}
+      {% set _ = environment_ns.names.append(secret_item.name) %}
+    {% endif %}
+  {% endfor %}
+  {% if environment_ns.items %}
     environment:
-
-{% for item in inline_env %}
-  {% if item.name not in environment_ns.names %}
-    {% set _ = environment_ns.items.append({'name': item.name, 'value': item.value}) %}
-    {% set _ = environment_ns.names.append(item.name) %}
-  {% endif %}
-{% endfor %}
-{% if secrets is defined and secrets.rotation_timestamp is defined and secrets.rotation_timestamp is not none %}
-  {% if 'SHMA_SECRETS_ROTATION' not in environment_ns.names %}
-    {% set _ = environment_ns.items.append({'name': 'SHMA_SECRETS_ROTATION', 'value': secrets.rotation_timestamp}) %}
-    {% set _ = environment_ns.names.append('SHMA_SECRETS_ROTATION') %}
-  {% endif %}
-{% endif %}
-{% for secret_item in svc_secret_env %}
-  {% if secret_item.name not in environment_ns.names %}
-    {% set _ = environment_ns.items.append({'name': secret_item.name, 'value': '${' ~ secret_item.name ~ '}'}) %}
-    {% set _ = environment_ns.names.append(secret_item.name) %}
-  {% endif %}
-{% endfor %}
-{% if environment_ns.items %}
-    environment:
-{% for env_item in environment_ns.items %}
+  {% for env_item in environment_ns.items %}
       {{ env_item.name }}: {{ env_item.value }}
-{% endfor %}
-{% endif %}
-{% if svc.entrypoint is defined %}
+  {% endfor %}
+  {% endif %}
+  {% if svc.entrypoint is defined %}
     entrypoint: {{ svc.entrypoint if svc.entrypoint is string else svc.entrypoint | to_json }}
 {% endif %}
 {% if svc.command is defined %}

--- a/tests/test_runtime_parity.py
+++ b/tests/test_runtime_parity.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+from typing import Iterable
+
+
+def _extend_sys_path_for_pipx() -> None:
+    """Ensure pipx-managed site-packages are importable for test utilities."""
+
+    pipx_venvs = Path.home() / ".local/share/pipx/venvs"
+    if not pipx_venvs.exists():
+        return
+
+    for venv in pipx_venvs.iterdir():
+        lib_dir = venv / "lib"
+        if not lib_dir.exists():
+            continue
+        for python_dir in lib_dir.iterdir():
+            site_packages = python_dir / "site-packages"
+            if site_packages.exists() and str(site_packages) not in sys.path:
+                sys.path.insert(0, str(site_packages))
+
+
+_extend_sys_path_for_pipx()
+
+import yaml  # type: ignore  # noqa: E402  (available via pipx ansible environment)
+
+
+class RuntimeParityTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.service_file = Path("tests/sample_service.yml").resolve()
+        cls.service_doc = yaml.safe_load(cls.service_file.read_text())
+        cls.service_id = cls.service_doc["service_id"]
+        cls.runtime_dir = Path("/tmp/ansible-runtime") / cls.service_id
+
+        if cls.runtime_dir.exists():
+            shutil.rmtree(cls.runtime_dir)
+
+        for runtime in ("docker", "podman"):
+            cls._render_runtime(runtime)
+
+        cls.compose_manifest_text = (cls.runtime_dir / "docker.yml").read_text()
+        cls.quadlet_manifest_text = (cls.runtime_dir / "podman.yml").read_text()
+        cls.quadlet_manifest_lines = tuple(
+            line.strip() for line in cls.quadlet_manifest_text.splitlines()
+        )
+
+        health = cls.service_doc.get("health", {}) or {}
+        cmd: Iterable[str] = health.get("cmd") or ["true"]
+        cls.expected_health_cmd = list(cmd)
+        cls.expected_health_cmd_string = " ".join(cls.expected_health_cmd)
+        cls.compose_service_name = cls.service_doc.get("service_name") or cls.service_id
+
+    @classmethod
+    def _render_runtime(cls, runtime: str) -> None:
+        command = [
+            "ansible-playbook",
+            "tests/render.yml",
+            "-e",
+            f"runtime={runtime}",
+            "-e",
+            f"service_definition_file={cls.service_file}",
+        ]
+        subprocess.run(command, check=True)
+
+    def _assert_health_cmd(self, runtime: str, actual: object) -> None:
+        if runtime == "docker":
+            self.assertEqual(self.expected_health_cmd, list(actual))
+        elif runtime == "podman":
+            self.assertEqual(self.expected_health_cmd_string, str(actual))
+        else:  # pragma: no cover - defensive guard for new runtimes
+            raise ValueError(f"Unsupported runtime {runtime}")
+
+    def test_quadlet_emits_security_defaults(self) -> None:
+        self.assertIn("ReadOnly=true", self.quadlet_manifest_lines)
+        self.assertIn("NoNewPrivileges=true", self.quadlet_manifest_lines)
+        self.assertIn("NoNewPrivileges=yes", self.quadlet_manifest_lines)
+
+        drop_caps = [
+            line
+            for line in self.quadlet_manifest_lines
+            if line.startswith("DropCapability=")
+        ]
+        self.assertTrue(drop_caps, "Expected at least one DropCapability directive")
+        self.assertIn("DropCapability=ALL", drop_caps)
+
+    def test_compose_health_cmd_matches_service_definition(self) -> None:
+        match = None
+        for line in self.compose_manifest_text.splitlines():
+            if "healthcheck" in line:
+                continue
+            if "test:" in line:
+                match = line
+                break
+        self.assertIsNotNone(
+            match, "Compose manifest missing healthcheck test definition"
+        )
+        _, _, raw = match.partition(":")
+        parsed = json.loads(raw.strip())
+        self._assert_health_cmd("docker", parsed)
+
+    def test_quadlet_health_cmd_matches_compose(self) -> None:
+        health_line = next(
+            (line for line in self.quadlet_manifest_lines if "HealthCmd=" in line),
+            None,
+        )
+        self.assertIsNotNone(health_line, "Quadlet manifest missing HealthCmd entry")
+        _, _, value = health_line.partition("HealthCmd=")
+        self._assert_health_cmd("podman", value.strip())
+
+
+if __name__ == "__main__":  # pragma: no cover - manual invocation
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a runtime parity unit test suite that verifies Quadlet security defaults and health command parity with Compose
- fix the Compose template environment rendering loop so inline and secret variables are merged without gating on existing items
- extend the no-inline secret scanner to include content-based secrets and inspect Quadlet manifests for embedded values

## Testing
- python -m unittest tests.test_runtime_parity

------
https://chatgpt.com/codex/tasks/task_e_68f41d247b58832e849ba14dfcf2ec46