### PR TITLE
Add Kubernetes manifest enforcement and verification

### DIFF
--- a/ci/verify_secret_rotation.py
+++ b/ci/verify_secret_rotation.py
@@ -1,0 +1,188 @@
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+from typing import List
+
+ROTATION_ANNOTATION = "shma.dev/secrets-rotation"
+
+
+def run_kubectl(args: List[str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["kubectl", *args],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+
+def get_deployment(namespace: str, deployment: str) -> dict:
+    result = run_kubectl(
+        [
+            "get",
+            "deployment",
+            deployment,
+            "-n",
+            namespace,
+            "-o",
+            "json",
+        ]
+    )
+    return json.loads(result.stdout)
+
+
+def get_pod_names(namespace: str, label_selector: str) -> list[str]:
+    result = run_kubectl(
+        [
+            "get",
+            "pods",
+            "-n",
+            namespace,
+            "-l",
+            label_selector,
+            "-o",
+            "json",
+        ]
+    )
+    payload = json.loads(result.stdout)
+    items = payload.get("items", [])
+    return sorted(item["metadata"]["name"] for item in items)
+
+
+def annotate_rotation(namespace: str, deployment: str, timestamp: str) -> None:
+    run_kubectl(
+        [
+            "annotate",
+            "deployment",
+            deployment,
+            "-n",
+            namespace,
+            f"{ROTATION_ANNOTATION}={timestamp}",
+            "--overwrite",
+        ]
+    )
+
+
+def wait_for_rollout(namespace: str, deployment: str, timeout: str) -> None:
+    run_kubectl(
+        [
+            "rollout",
+            "status",
+            f"deployment/{deployment}",
+            "-n",
+            namespace,
+            "--timeout",
+            timeout,
+        ]
+    )
+
+
+def validate_rotation_env(namespace: str, pod_name: str, timestamp: str) -> None:
+    result = run_kubectl(
+        [
+            "get",
+            "pod",
+            pod_name,
+            "-n",
+            namespace,
+            "-o",
+            "json",
+        ]
+    )
+    payload = json.loads(result.stdout)
+    containers = payload.get("spec", {}).get("containers", [])
+    if not containers:
+        raise SystemExit(f"Pod {pod_name} has no containers to inspect.")
+
+    env_list = containers[0].get("env", [])
+    for entry in env_list:
+        if (
+            entry.get("name") == "SHMA_SECRETS_ROTATION"
+            and entry.get("value") == timestamp
+        ):
+            return
+    raise SystemExit(
+        f"Pod {pod_name} is missing SHMA_SECRETS_ROTATION={timestamp} after rotation."
+    )
+
+
+def ensure_secret_rotation(
+    namespace: str,
+    deployment: str,
+    timestamp: str,
+    timeout: str,
+    label_selector: str | None,
+) -> None:
+    selector = label_selector or f"app={deployment}"
+    deployment_doc = get_deployment(namespace, deployment)
+    current_annotation = (
+        deployment_doc.get("spec", {})
+        .get("template", {})
+        .get("metadata", {})
+        .get("annotations", {})
+        .get(ROTATION_ANNOTATION)
+    )
+
+    if current_annotation == timestamp:
+        raise SystemExit(
+            f"Deployment {deployment} already has {ROTATION_ANNOTATION}={timestamp}; provide a new timestamp to trigger rotation."
+        )
+
+    initial_pods = get_pod_names(namespace, selector)
+    if not initial_pods:
+        raise SystemExit(
+            f"No pods found for deployment {deployment} using selector {selector}."
+        )
+
+    annotate_rotation(namespace, deployment, timestamp)
+    wait_for_rollout(namespace, deployment, timeout)
+
+    refreshed_pods = get_pod_names(namespace, selector)
+    if not refreshed_pods:
+        raise SystemExit("No pods found after applying the rotation annotation.")
+
+    if not set(refreshed_pods) - set(initial_pods):
+        raise SystemExit(
+            "Secret rotation annotation did not trigger a new ReplicaSet; pod names are unchanged."
+        )
+
+    validate_rotation_env(namespace, refreshed_pods[0], timestamp)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Verify that updating secrets.rotation_timestamp triggers a rollout in Kubernetes"
+        )
+    )
+    parser.add_argument(
+        "namespace", help="Kubernetes namespace containing the deployment"
+    )
+    parser.add_argument("deployment", help="Deployment name to annotate")
+    parser.add_argument("timestamp", help="New secrets.rotation_timestamp value")
+    parser.add_argument(
+        "--timeout",
+        default="120s",
+        help="Timeout to wait for the rollout to complete (default: 120s)",
+    )
+    parser.add_argument(
+        "--label-selector",
+        help="Optional label selector used to find pods (defaults to app=<deployment>)",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    ensure_secret_rotation(
+        namespace=args.namespace,
+        deployment=args.deployment,
+        timestamp=args.timestamp,
+        timeout=args.timeout,
+        label_selector=args.label_selector,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/policy/kubernetes.rego
+++ b/policy/kubernetes.rego
@@ -10,6 +10,26 @@ resources[resource] {
   resource := input
 }
 
+all_containers(resource)[container] {
+  resource.kind == "Deployment"
+  template := object.get(resource.spec, "template", {})
+  spec := object.get(template, "spec", {})
+  containers := object.get(spec, "containers", [])
+  container := containers[_]
+}
+
+all_containers(resource)[container] {
+  resource.kind == "Deployment"
+  template := object.get(resource.spec, "template", {})
+  spec := object.get(template, "spec", {})
+  init_containers := object.get(spec, "initContainers", [])
+  container := init_containers[_]
+}
+
+image_has_digest(image) {
+  contains(image, "@sha256:")
+}
+
 deprecated_apis := {
   "extensions/v1beta1",
   "apps/v1beta1",
@@ -26,4 +46,42 @@ deny[msg] {
   name := resource.metadata.name
   kind := resource.kind
   msg := sprintf("%s/%s uses deprecated apiVersion %s", [kind, name, api])
+}
+
+deny[msg] {
+  deployment := resources[_]
+  deployment.kind == "Deployment"
+  container := all_containers(deployment)[_]
+  image := container.image
+  image != null
+  not image_has_digest(image)
+  namespace := object.get(deployment.metadata, "namespace", "default")
+  name := object.get(deployment.metadata, "name", "<unnamed>")
+  container_name := object.get(container, "name", "<unnamed>")
+  msg := sprintf(
+    "Deployment %s/%s container %s image %q must include an @sha256 digest",
+    [namespace, name, container_name, image],
+  )
+}
+
+deny[msg] {
+  deployment := resources[_]
+  deployment.kind == "Deployment"
+  namespace := object.get(deployment.metadata, "namespace", "default")
+  template := object.get(deployment.spec, "template", {})
+  template_spec := object.get(template, "spec", {})
+  volumes := object.get(template_spec, "volumes", [])
+  volume := volumes[_]
+  host_path := volume.hostPath
+  host_path != null
+  pvc := resources[_]
+  pvc.kind == "PersistentVolumeClaim"
+  object.get(pvc.metadata, "namespace", namespace) == namespace
+  object.get(pvc.metadata, "name", "") == object.get(volume, "name", "")
+  deployment_name := object.get(deployment.metadata, "name", "<unnamed>")
+  volume_name := object.get(volume, "name", "<unnamed>")
+  msg := sprintf(
+    "Deployment %s/%s volume %s cannot use a hostPath alongside a PersistentVolumeClaim",
+    [namespace, deployment_name, volume_name],
+  )
 }

--- a/schemas/service.schema.yml
+++ b/schemas/service.schema.yml
@@ -382,3 +382,17 @@ allOf:
       properties:
         needs_container_runtime:
           const: true
+  - if:
+      properties:
+        service_volumes:
+          type: array
+          contains:
+            type: object
+            required:
+              - host_path
+    then:
+      properties:
+        kubernetes:
+          not:
+            required:
+              - pvc

--- a/templates/kubernetes.yml.j2
+++ b/templates/kubernetes.yml.j2
@@ -1,5 +1,6 @@
+#jinja2: lstrip_blocks: True, trim_blocks: True
 {% set svc_name = service_name | default(service_id) %}
-{% set namespace = service_namespace | default('default') %}
+{% set svc_namespace = service_namespace | default('default') %}
 {% set mounts_config = mounts | default({}) %}
 {% set ephemeral_mounts = mounts_config.ephemeral_mounts | default([]) %}
 {% set default_apply_targets = ['docker', 'podman', 'kubernetes', 'proxmox', 'baremetal'] %}
@@ -13,7 +14,8 @@
 {% set allow_priv_escalation = security.allow_privilege_escalation if security.allow_privilege_escalation is defined else (not no_new_privs) %}
 {% set ingress_spec = ingress | default({}) %}
 {% set ingress_routes = ingress_spec.routes | default([]) %}
-{% set ingress_enabled = (ingress_spec.enabled if ingress_spec is mapping and ingress_spec.enabled is not none else (ingress_routes | length > 0)) %}
+{% set ingress_flag = ingress_spec.get('enabled') if ingress_spec is mapping else none %}
+{% set ingress_enabled = (ingress_flag if ingress_flag is not none else (ingress_routes | length > 0)) %}
 {% set k8s_ephemeral = namespace(items=[]) %}
 {% for mount in ephemeral_mounts %}
   {% set apply_targets = mount.apply_to | default(default_apply_targets) %}
@@ -31,7 +33,8 @@
 {% endfor %}
 {% set secret_env = secrets.env if secrets is defined and secrets.env is not none and secrets.env | length > 0 else [] %}
 {% set file_secrets = secrets.files if secrets is defined and secrets.files is not none and secrets.files | length > 0 else [] %}
-{% set inline_env = service_env | default([]) %}
+{% set inline_env = service_env | default([]) | list %}
+{% set inline_env_ns = namespace(items=inline_env) %}
 {% set env_secret_name = svc_name + '-env' %}
 {% set file_secret_name = svc_name + '-files' %}
 {% set health_cmd = health.cmd | default(['true']) %}
@@ -60,52 +63,52 @@
 {% set storage_size = '1Gi' %}
 {% endif %}
 {% set volume_mount_path = volume_config.target if volume_config is mapping and volume_config.target is defined else '/data' %}
-{% if secret_env %}
+{%- if secret_env -%}
 ---
 apiVersion: v1
 kind: Secret
 metadata:
   name: {{ env_secret_name }}
-  namespace: {{ namespace }}
+  namespace: {{ svc_namespace }}
 type: Opaque
 stringData:
 {% for item in secret_env %}
   {{ item.name }}: {{ item.value | to_json }}
 {% endfor %}
-{% endif %}
-{% if file_secrets %}
+{% endif -%}
+{%- if file_secrets -%}
 ---
 apiVersion: v1
 kind: Secret
 metadata:
   name: {{ file_secret_name }}
-  namespace: {{ namespace }}
+  namespace: {{ svc_namespace }}
 type: Opaque
 stringData:
 {% for secret in file_secrets %}
   {{ secret.name }}: {{ (secret.value | default(secret.content) | default('', true)) | to_json }}
 {% endfor %}
-{% endif %}
-{% if not use_host_path %}
+{% endif -%}
+{%- if not use_host_path -%}
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: {{ svc_name }}-data
-  namespace: {{ namespace }}
+  namespace: {{ svc_namespace }}
 spec:
   accessModes:
     - ReadWriteOnce
   resources:
     requests:
       storage: {{ storage_size }}
-{% endif %}
+{% endif -%}
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ svc_name }}
-  namespace: {{ namespace }}
+  namespace: {{ svc_namespace }}
 spec:
   replicas: {{ replicas }}
   selector:
@@ -138,6 +141,13 @@ spec:
                 - {{ cap }}
 {% endfor %}
 {% endif %}
+{% if secrets is defined and secrets.rotation_timestamp is defined and secrets.rotation_timestamp is not none %}
+  {% set _ = inline_env_ns.items.append({'name': 'SHMA_SECRETS_ROTATION', 'value': secrets.rotation_timestamp | string}) %}
+{% endif %}
+{% if connections_per_second is not none %}
+  {% set _ = inline_env_ns.items.append({'name': 'CONNECTIONS_PER_SECOND', 'value': connections_per_second | string}) %}
+{% endif %}
+{% set inline_env = inline_env_ns.items %}
 {% set has_secret_env = secret_env | length > 0 %}
 {% set has_inline_env = inline_env | length > 0 %}
 {% if has_secret_env or has_inline_env %}
@@ -154,18 +164,9 @@ spec:
 {% if has_inline_env %}
 {% for item in inline_env %}
             - name: {{ item.name }}
-              value: {{ item.value }}
+              value: {{ item.value | to_json }}
 {% endfor %}
-{% if secrets is defined and secrets.rotation_timestamp is defined and secrets.rotation_timestamp is not none %}
-            - name: SHMA_SECRETS_ROTATION
-              value: {{ secrets.rotation_timestamp | to_json }}
-
-{% if connections_per_second %}
-            - name: CONNECTIONS_PER_SECOND
-              value: "{{ connections_per_second }}"
-
 {% endif %}
-
 {% endif %}
           ports:
             - containerPort: {{ container_port }}
@@ -246,7 +247,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ svc_name }}
-  namespace: {{ namespace }}
+  namespace: {{ svc_namespace }}
 spec:
   selector:
     app: {{ svc_name }}
@@ -268,7 +269,7 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ svc_name }}
-  namespace: {{ namespace }}
+  namespace: {{ svc_namespace }}
   labels:
     app: {{ svc_name }}
 spec:

--- a/tests/sample_service.yml
+++ b/tests/sample_service.yml
@@ -93,6 +93,7 @@ runtime_templates:
   baremetal: ../templates/baremetal.yml.j2
 secrets:
   shred_after_apply: true
+  rotation_timestamp: "2024-08-20T12:34:56Z"
   env:
     - name: SAMPLE_SERVICE_TOKEN
       value: super-secret-token

--- a/tests/verify_kubernetes_manifest.yml
+++ b/tests/verify_kubernetes_manifest.yml
@@ -1,0 +1,144 @@
+---
+- name: Validate Kubernetes manifest secrets and probes
+  hosts: localhost
+  gather_facts: false
+  connection: local
+  vars:
+    runtime: kubernetes
+  tasks:
+    - name: Load sample service definition
+      ansible.builtin.include_vars:
+        file: "{{ playbook_dir }}/sample_service.yml"
+
+    - name: Render Kubernetes runtime
+      ansible.builtin.include_role:
+        name: roles/common/render_runtime
+
+    - name: Read rendered manifest
+      ansible.builtin.slurp:
+        src: "{{ runtime_config_path }}"
+      register: rendered_manifest
+
+    - name: Parse manifest documents
+      ansible.builtin.set_fact:
+        manifest_documents: "{{ rendered_manifest.content | b64decode | from_yaml_all | list }}"
+
+    - name: Filter Kubernetes resources
+      ansible.builtin.set_fact:
+        kubernetes_resources: "{{ manifest_documents | reject('equalto', None) | list }}"
+
+    - name: Determine deployment metadata
+      ansible.builtin.set_fact:
+        deployment_name: "{{ service_name | default(service_id) }}"
+        expected_health_cmd: "{{ health.cmd | default(['true']) }}"
+
+    - name: Collect Kubernetes resources by kind
+      ansible.builtin.set_fact:
+        deployment_resources: "{{ kubernetes_resources | selectattr('kind', '==', 'Deployment') | selectattr('metadata.name', '==', deployment_name) | list }}"
+        env_secret_resources: "{{ kubernetes_resources | selectattr('kind', '==', 'Secret') | selectattr('metadata.name', '==', deployment_name ~ '-env') | list }}"
+        file_secret_resources: "{{ kubernetes_resources | selectattr('kind', '==', 'Secret') | selectattr('metadata.name', '==', deployment_name ~ '-files') | list }}"
+        pvc_resources: "{{ kubernetes_resources | selectattr('kind', '==', 'PersistentVolumeClaim') | list }}"
+
+    - name: Validate environment secret layout
+      ansible.builtin.assert:
+        that:
+          - env_secret_resources | length == 1
+          - env_secret_resources[0].stringData.SAMPLE_SERVICE_TOKEN is defined
+          - env_secret_resources[0].stringData.SAMPLE_SERVICE_TOKEN == 'super-secret-token'
+          - "'tls-cert' not in env_secret_resources[0].stringData"
+        fail_msg: "Environment secrets must reside in the <service>-env secret."
+
+    - name: Validate file secret layout
+      ansible.builtin.assert:
+        that:
+          - file_secret_resources | length == 1
+          - file_secret_resources[0].stringData['tls-cert'] is defined
+          - file_secret_resources[0].stringData['tls-cert'] | length > 0
+          - "'SAMPLE_SERVICE_TOKEN' not in file_secret_resources[0].stringData"
+        fail_msg: "File secrets must reside in the <service>-files secret."
+
+    - name: Ensure PVC excluded when hostPath is configured
+      ansible.builtin.assert:
+        that:
+          - pvc_resources | length == 0
+        fail_msg: "PersistentVolumeClaims must be omitted when hostPath storage is requested."
+
+    - name: Ensure deployment resource rendered
+      ansible.builtin.assert:
+        that:
+          - deployment_resources | length == 1
+        fail_msg: "Expected a single Deployment resource in the manifest."
+
+    - name: Extract deployment details
+      ansible.builtin.set_fact:
+        deployment_resource: "{{ deployment_resources[0] }}"
+        container_specs: "{{ deployment_resources[0].spec.template.spec.containers | default([]) }}"
+        pod_volumes: "{{ deployment_resources[0].spec.template.spec.volumes | default([]) }}"
+
+    - name: Validate deployment annotations and container presence
+      ansible.builtin.assert:
+        that:
+          - container_specs | length > 0
+          - deployment_resource.spec.template.metadata.annotations['shma.dev/secrets-rotation'] == secrets.rotation_timestamp
+        fail_msg: "Deployment must contain containers and the rotation annotation."
+
+    - name: Select primary container
+      ansible.builtin.set_fact:
+        primary_container: "{{ container_specs[0] }}"
+        container_env: "{{ container_specs[0].env | default([]) }}"
+        container_volume_mounts: "{{ container_specs[0].volumeMounts | default([]) }}"
+
+    - name: Locate env entries for assertions
+      ansible.builtin.set_fact:
+        secret_env_entry_list: "{{ container_env | selectattr('name', '==', 'SAMPLE_SERVICE_TOKEN') | list }}"
+        rotation_env_entry_list: "{{ container_env | selectattr('name', '==', 'SHMA_SECRETS_ROTATION') | list }}"
+        cps_env_entry_list: "{{ container_env | selectattr('name', '==', 'CONNECTIONS_PER_SECOND') | list }}"
+
+    - name: Validate environment wiring for secrets and rate limits
+      ansible.builtin.assert:
+        that:
+          - secret_env_entry_list | length == 1
+          - secret_env_entry_list[0].valueFrom.secretKeyRef.name == deployment_name ~ '-env'
+          - rotation_env_entry_list | length == 1
+          - rotation_env_entry_list[0].value == secrets.rotation_timestamp
+          - cps_env_entry_list | length == 1
+          - cps_env_entry_list[0].value == (service_resources.connections_per_second | string)
+        fail_msg: "Container environment variables must include rotation and rate limit markers."
+
+    - name: Validate file secret mounts
+      ansible.builtin.set_fact:
+        file_mounts: "{{ container_volume_mounts | selectattr('name', '==', 'secret-files') | list }}"
+
+    - name: Assert file secret mounts present
+      ansible.builtin.assert:
+        that:
+          - file_mounts | selectattr('subPath', '==', 'tls-cert') | list | length == 1
+          - file_mounts | selectattr('mountPath', '==', '/etc/sample-service/certs/tls.crt') | list | length == 1
+        fail_msg: "File secrets must mount using the shared secret-files volume."
+
+    - name: Validate secret volume wiring
+      ansible.builtin.set_fact:
+        secret_volume_entries: "{{ pod_volumes | selectattr('name', '==', 'secret-files') | list }}"
+        data_volume_entries: "{{ pod_volumes | selectattr('name', '==', 'data') | list }}"
+
+    - name: Assert secret volume configuration
+      ansible.builtin.assert:
+        that:
+          - secret_volume_entries | length == 1
+          - secret_volume_entries[0].secret.secretName == deployment_name ~ '-files'
+          - secret_volume_entries[0].secret['items'] | selectattr('key', '==', 'tls-cert') | list | length == 1
+        fail_msg: "Deployment must project the file secrets volume."
+
+    - name: Assert hostPath volume replaces PVC
+      ansible.builtin.assert:
+        that:
+          - data_volume_entries | length == 1
+          - data_volume_entries[0].hostPath.path == service_volumes[0].host_path
+        fail_msg: "HostPath volume should back the primary data mount."
+
+    - name: Validate health probe commands
+      ansible.builtin.assert:
+        that:
+          - primary_container.livenessProbe.exec.command == expected_health_cmd
+          - primary_container.readinessProbe.exec.command == expected_health_cmd
+        fail_msg: "Liveness and readiness probes must reuse the declared health.cmd."


### PR DESCRIPTION
## Summary
- enforce container image digest usage and prevent hostPath plus PVC mounts via Conftest
- block schema combinations that set both hostPath volumes and Kubernetes PVCs
- update Kubernetes template to wire secrets, probes, annotations, and rate limits consistently
- add fixtures and automation to verify manifest layout and secret rotation rollouts

## Testing
- ansible-playbook tests/verify_kubernetes_manifest.yml

------
https://chatgpt.com/codex/tasks/task_e_68f41d293b94832ebfcf40757b4bc377