### PR TITLE
Ensure systemd hardening and shared health checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,6 +163,12 @@ PY
       - name: Validate systemd unit
         run: systemd-analyze verify ${{ steps.metadata.outputs.runtime_dir }}/baremetal.yml
 
+      - name: Enforce systemd unit hardening
+        run: |
+          python ci/validate_systemd_unit.py \
+            --service-definition "${{ matrix.service_file }}" \
+            "${{ steps.metadata.outputs.runtime_dir }}/baremetal.yml"
+
       - name: Render Kubernetes manifests
         run: ansible-playbook tests/render.yml -e runtime=kubernetes -e service_definition_file=${{ matrix.service_file }}
 

--- a/ci/run_kubernetes_health_checks.py
+++ b/ci/run_kubernetes_health_checks.py
@@ -8,14 +8,15 @@ from typing import List
 
 import yaml
 
+from filter_plugins.health import get_health_command
+
 
 def load_health_command(service_file: Path) -> List[str]:
     document = yaml.safe_load(service_file.read_text())
-    health = document.get("health") or {}
-    command = health.get("cmd") or ["true"]
-    if not isinstance(command, list):
-        raise SystemExit("health.cmd must be an array of command arguments")
-    return [str(arg) for arg in command]
+    try:
+        return get_health_command(document.get("health"))
+    except ValueError as exc:
+        raise SystemExit(str(exc)) from exc
 
 
 def ensure_health(namespace: str, app_name: str, command: List[str]) -> None:

--- a/ci/validate_systemd_unit.py
+++ b/ci/validate_systemd_unit.py
@@ -1,0 +1,150 @@
+"""Validate rendered bare-metal systemd units for hardened defaults."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from typing import Dict, Iterable, List
+
+import yaml
+
+DEFAULT_APPLY_TARGETS = ["docker", "podman", "kubernetes", "proxmox", "baremetal"]
+
+
+def parse_unit(unit_path: Path) -> Dict[str, Dict[str, List[str]]]:
+    sections: Dict[str, Dict[str, List[str]]] = {}
+    current_section: str | None = None
+
+    for raw_line in unit_path.read_text(encoding="utf-8").splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#") or line.startswith(";"):
+            continue
+        if line.startswith("[") and line.endswith("]"):
+            current_section = line[1:-1]
+            sections.setdefault(current_section, {})
+            continue
+        if "=" not in raw_line or current_section is None:
+            continue
+        key, value = raw_line.split("=", 1)
+        key = key.strip()
+        value = value.strip()
+        section_entries = sections.setdefault(current_section, {})
+        section_entries.setdefault(key, []).append(value)
+
+    return sections
+
+
+def load_service_definition(path: Path) -> dict:
+    with path.open("r", encoding="utf-8") as handle:
+        return yaml.safe_load(handle)
+
+
+def enforce_protect_system(service: dict) -> bool:
+    security = service.get("service_security") or {}
+    unit_overrides = (service.get("service_unit") or {}).get("service") or {}
+    if "ProtectSystem" in unit_overrides:
+        return False
+    if "protect_system" in security:
+        return False
+    if "read_only_root_filesystem" in security:
+        return False
+    return True
+
+
+def enforce_protect_home(service: dict) -> bool:
+    security = service.get("service_security") or {}
+    unit_overrides = (service.get("service_unit") or {}).get("service") or {}
+    if "ProtectHome" in unit_overrides:
+        return False
+    if "protect_home" in security:
+        return False
+    return True
+
+
+def ephemeral_paths_for_baremetal(service: dict) -> List[str]:
+    mounts = (service.get("mounts") or {}).get("ephemeral_mounts") or []
+    paths: List[str] = []
+    for mount in mounts:
+        path = mount.get("path")
+        if not path:
+            continue
+        apply_to: Iterable[str] | None = mount.get("apply_to")
+        if not apply_to:
+            apply_to = DEFAULT_APPLY_TARGETS
+        if "baremetal" in apply_to:
+            paths.append(path)
+    return paths
+
+
+def validate_unit(unit_path: Path, service_path: Path) -> int:
+    service = load_service_definition(service_path)
+    unit_sections = parse_unit(unit_path)
+    service_section = unit_sections.get("Service")
+
+    errors: List[str] = []
+    if service_section is None:
+        errors.append("[Service] section missing from unit file")
+        service_section = {}
+
+    if enforce_protect_system(service):
+        values = service_section.get("ProtectSystem", [])
+        if not values:
+            errors.append("ProtectSystem directive missing from [Service] section")
+        elif values[-1].strip().lower() != "strict":
+            errors.append(
+                f"ProtectSystem is {values[-1]!r}; expected 'strict' for hardened default"
+            )
+
+    if enforce_protect_home(service):
+        values = service_section.get("ProtectHome", [])
+        if not values:
+            errors.append("ProtectHome directive missing from [Service] section")
+        elif values[-1].strip().lower() != "yes":
+            errors.append(
+                f"ProtectHome is {values[-1]!r}; expected 'yes' for hardened default"
+            )
+
+    expected_tmpfs = ephemeral_paths_for_baremetal(service)
+    if expected_tmpfs:
+        tmpfs_entries = service_section.get("TemporaryFileSystem", [])
+        missing = []
+        for path in expected_tmpfs:
+            if not any(entry.split(":", 1)[0] == path for entry in tmpfs_entries):
+                missing.append(path)
+        if missing:
+            errors.append(
+                "Missing TemporaryFileSystem entries for ephemeral mounts: "
+                + ", ".join(sorted(missing))
+            )
+
+    if errors:
+        for error in errors:
+            print(f"{unit_path}: {error}")
+        return 1
+
+    print(f"Validated systemd unit security directives in {unit_path}")
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Validate rendered systemd unit security directives",
+    )
+    parser.add_argument("unit", type=Path, help="Path to rendered systemd unit")
+    parser.add_argument(
+        "--service-definition",
+        type=Path,
+        required=True,
+        help="Service definition used to render the unit",
+    )
+    return parser
+
+
+def main() -> int:
+    parser = build_parser()
+    args = parser.parse_args()
+    return validate_unit(args.unit, args.service_definition)
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    raise SystemExit(main())

--- a/filter_plugins/health.py
+++ b/filter_plugins/health.py
@@ -1,0 +1,59 @@
+"""Health command helpers shared between Ansible and CI tooling."""
+
+from __future__ import annotations
+
+from typing import Any, Iterable, List
+
+
+DEFAULT_COMMAND = ["true"]
+
+
+def get_health_command(health: Any | None) -> List[str]:
+    """Return the normalized health command list.
+
+    Parameters
+    ----------
+    health:
+        Mapping or object that may contain a ``cmd`` attribute/entry.
+
+    Returns
+    -------
+    list[str]
+        Sanitised command arguments with all entries coerced to strings.
+
+    Raises
+    ------
+    ValueError
+        If ``health.cmd`` exists but is not a list/iterable of arguments.
+    """
+
+    if not health:
+        return DEFAULT_COMMAND.copy()
+
+    # Support both dict-style and attribute-style access.
+    command: Any | None = None
+    if isinstance(health, dict):
+        command = health.get("cmd")
+    else:
+        command = getattr(health, "cmd", None)
+
+    if command is None:
+        return DEFAULT_COMMAND.copy()
+
+    if not isinstance(command, Iterable) or isinstance(command, (str, bytes)):
+        raise ValueError("health.cmd must be an iterable of arguments")
+
+    return [str(arg) for arg in command]
+
+
+def health_command_filter(health: Any | None) -> List[str]:
+    return get_health_command(health)
+
+
+class FilterModule:
+    """Expose health command helpers to Ansible."""
+
+    def filters(self) -> dict[str, Any]:
+        return {
+            "health_command": health_command_filter,
+        }

--- a/roles/common/apply_runtime/tasks/main.yml
+++ b/roles/common/apply_runtime/tasks/main.yml
@@ -3,9 +3,11 @@
   include_tasks: "{{ runtime }}.yml"
 
 - name: Health check after deployment
-  command: "{{ health.cmd[0] if health.cmd is defined else 'true' }}"
+  vars:
+    apply_runtime_health_command: {{ health | health_command }}
+  command: "{{ apply_runtime_health_command[0] }}"
   args:
-    argv: {{ health.cmd }}
+    argv: {{ apply_runtime_health_command }}
   delegate_to: "{{ service_ip | default(ansible_default_ipv4.address) }}"
   retries: {{ health.retries | default(3) }}
   delay: {{ health.interval | default('10s') | regex_replace('s$', '') | int }}

--- a/roles/common/render_runtime/tasks/main.yml
+++ b/roles/common/render_runtime/tasks/main.yml
@@ -53,6 +53,19 @@
     - render_ephemeral_mount_paths is defined
     - render_ephemeral_mount_paths | length > 0
 
+- name: Enforce secret shredding waiver when disabled
+  assert:
+    that:
+      - secrets.shred_waiver_reason is defined
+      - (secrets.shred_waiver_reason | string | trim | length) > 0
+    fail_msg: >-
+      secrets.shred_after_apply cannot be set to false without documenting a
+      shred_waiver_reason that explains why persistent secret artifacts are acceptable.
+  when:
+    - secrets is defined
+    - secrets.shred_after_apply is defined
+    - not (secrets.shred_after_apply | bool)
+
 - name: Check if runtime is supported
   assert:
     that:


### PR DESCRIPTION
## Summary
- add a shared health command helper and reuse it in the post-deploy gate and KinD health checks
- enforce the documented ProtectSystem/ProtectHome/TemporaryFileSystem defaults in rendered bare-metal units via a dedicated validator
- require a shred_waiver_reason whenever secrets.shred_after_apply is false during runtime rendering

## Testing
- ansible-playbook tests/render.yml -e runtime=baremetal


------
https://chatgpt.com/codex/tasks/task_e_68f41d306b80832e95b1949edc36a604