### PR TITLE
Harden Docker runtime secret handling and cleanup

### DIFF
--- a/roles/common/apply_runtime/tasks/docker.yml
+++ b/roles/common/apply_runtime/tasks/docker.yml
@@ -38,22 +38,54 @@
   when: compose_secret_files | length > 0
   no_log: true
 
-- name: Deploy with Docker Compose v2
-  community.docker.docker_compose_v2:
-    project_src: "{{ runtime_output_dir }}"
-    files:
-      - "{{ runtime_config_path | basename }}"
-    state: present
-    pull: always
+- name: Verify Docker daemon is running
+  ansible.builtin.command: docker info
+  register: docker_daemon_info
+  changed_when: false
 
-  environment: "{{ compose_secret_env_map if compose_secret_env_map else omit }}"
-  no_log: "{{ compose_secret_env | length > 0 }}"
+- name: Deploy with Docker Compose v2
+  block:
+    - name: Deploy Docker Compose project
+      community.docker.docker_compose_v2:
+        project_src: "{{ runtime_output_dir }}"
+        files:
+          - "{{ runtime_config_path | basename }}"
+        state: present
+        pull: always
+
+      environment: "{{ compose_secret_env_map if compose_secret_env_map else omit }}"
+      no_log: "{{ compose_secret_env | length > 0 }}"
+  rescue:
+    - name: Remove failed Docker Compose deployment
+      community.docker.docker_compose_v2:
+        project_src: "{{ runtime_output_dir }}"
+        files:
+          - "{{ runtime_config_path | basename }}"
+        state: absent
+        remove_orphans: true
+      ignore_errors: true
+
+    - name: Report Docker Compose failure after cleanup
+      ansible.builtin.fail:
+        msg: >-
+          Docker Compose deployment failed and orphaned containers were removed:
+          {{ ansible_failed_result.msg | default(ansible_failed_result.stderr, true) }}
 
 - name: Remove Compose secret files after apply
-  file:
-    path: "{{ runtime_output_dir }}/secrets/{{ item.name }}"
-    state: absent
+  ansible.builtin.command:
+    cmd: "shred --remove=unlink --zero {{ runtime_output_dir }}/secrets/{{ item.name }}"
+  args:
+    removes: "{{ runtime_output_dir }}/secrets/{{ item.name }}"
   loop: "{{ compose_secret_files }}"
+  when:
+    - compose_secret_shred | bool
+    - compose_secret_files | length > 0
+  no_log: true
+
+- name: Remove Compose secret directory after apply
+  ansible.builtin.file:
+    path: "{{ runtime_output_dir }}/secrets"
+    state: absent
   when:
     - compose_secret_shred | bool
     - compose_secret_files | length > 0

--- a/roles/common/apply_runtime/tasks/secret_cleanup.yml
+++ b/roles/common/apply_runtime/tasks/secret_cleanup.yml
@@ -1,18 +1,20 @@
 ---
-- name: Remove secret environment file after apply
-  ansible.builtin.file:
-    path: "{{ cleanup_secret_context.env_path }}"
-    state: absent
+- name: Securely shred secret environment file after apply
+  ansible.builtin.command:
+    cmd: "shred --remove=unlink --zero {{ cleanup_secret_context.env_path }}"
+  args:
+    removes: "{{ cleanup_secret_context.env_path }}"
   when:
     - cleanup_secret_context.shred | default(true) | bool
     - cleanup_secret_context.env | default([]) | length > 0
   become: "{{ cleanup_secret_context.become | default(false) }}"
   no_log: "{{ cleanup_secret_context.env_no_log | default(false) }}"
 
-- name: Remove secret files after apply
-  ansible.builtin.file:
-    path: "{{ cleanup_secret_context.directory }}/{{ item.name }}"
-    state: absent
+- name: Securely shred secret files after apply
+  ansible.builtin.command:
+    cmd: "shred --remove=unlink --zero {{ cleanup_secret_context.directory }}/{{ item.name }}"
+  args:
+    removes: "{{ cleanup_secret_context.directory }}/{{ item.name }}"
   loop: "{{ cleanup_secret_context.files | default([]) }}"
   when:
     - cleanup_secret_context.shred | default(true) | bool


### PR DESCRIPTION
## Summary
- ensure the Docker daemon is running before attempting a Compose deployment
- wrap the Docker Compose deployment in a rescue block that removes orphaned containers on failure
- securely shred Docker runtime secret files both in-task and in the shared secret cleanup handler

## Testing
- Not run (ansible-lint is not available in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68f505750164832e91c73837e28ce12a