### PR TITLE
Fix Podman quadlet template security gaps

### DIFF
--- a/docs/podman.md
+++ b/docs/podman.md
@@ -11,7 +11,8 @@ Deploy services using Podman Quadlets with environment files, optional user scop
 - `service_volumes.host_path` entries render as direct bind mounts so containers remain ephemeral while state lives on the host.
 - `service_image` entries should be digest-pinned; combine with `quadlet_auto_update: none` to ensure only vetted images run.
 - `mounts.ephemeral_mounts` entries become `Tmpfs=` declarations hardened with `nosuid`, `nodev`, and `noexec` so containers only write to explicitly allowed paths.
-- Containers default to `User=65532:65532`, `ReadOnly=true`, `NoNewPrivileges=true`, `DropCapability=ALL`, and an empty `CapabilityBoundingSet`. Override with `service_security` only when workloads need extra permissions.
+- Containers default to `User=65532:65532`, `ReadOnly=true`, `NoNewPrivileges=true`, `DropCapability=ALL`, and omit `CapabilityBoundingSet` unless you provide an explicit allow-list through `service_security.capability_bounding_set`. Override with `service_security` only when workloads need extra permissions.
+- Set `service_security.user_namespace` to wire Podman's `UserNS=` quadlet directive (for example `keep-id` or `auto`).
 - `secrets.rotation_timestamp` (optional) is written as an inline environment variable so Quadlet restarts the container whenever you bump the value.
 
 - `service_resources.connections_per_second` surfaces as a `CONNECTIONS_PER_SECOND` variable so an nginx/envoy sidecar can
@@ -66,7 +67,6 @@ HealthRetries=3
 Restart=always
 TimeoutStartSec=900
 NoNewPrivileges=yes
-CapabilityBoundingSet=
 
 [Install]
 WantedBy=multi-user.target default.target

--- a/schemas/service.schema.yml
+++ b/schemas/service.schema.yml
@@ -342,6 +342,8 @@ properties:
         type: array
         items:
           type: string
+      user_namespace:
+        type: string
       apparmor_profile:
         type: string
       private_tmp:

--- a/templates/podman.yml.j2
+++ b/templates/podman.yml.j2
@@ -1,3 +1,5 @@
+{% set unit = service_unit | default({}) %}
+{% set unit_description = unit.description | default('Managed container for ' ~ (service_name | default(service_id))) %}
 {% set mounts_config = mounts | default({}) %}
 {% set ephemeral_mounts = mounts_config.ephemeral_mounts | default([]) %}
 {% set default_apply_targets = ['docker', 'podman', 'kubernetes', 'proxmox', 'baremetal'] %}
@@ -12,19 +14,31 @@
 {% set bounding_set = security.capability_bounding_set if security.capability_bounding_set is defined else [] %}
 {% if bounding_set is string %}{% set bounding_set = [bounding_set] %}{% endif %}
 {% set tmpfs_hardening_flags = ['nosuid', 'nodev', 'noexec'] %}
-{% set podman_tmpfs = namespace(items=[]) %}
+{% set podman_tmpfs = namespace(entries=[]) %}
 {% for mount in ephemeral_mounts %}
   {% set apply_targets = mount.apply_to | default(default_apply_targets) %}
   {% if 'podman' in apply_targets %}
-    {% set options = [] %}
-    {% for flag in tmpfs_hardening_flags %}
-      {% if flag not in options %}{% set _ = options.append(flag) %}{% endif %}
+    {% set existing = none %}
+    {% for item in podman_tmpfs.entries %}
+      {% if item.path == mount.path %}
+        {% set existing = item %}
+      {% endif %}
     {% endfor %}
-    {% if mount.size is defined %}{% set _ = options.append('size=' ~ mount.size) %}{% endif %}
-    {% if mount.mode is defined %}{% set _ = options.append('mode=' ~ mount.mode) %}{% endif %}
-    {% set entry = mount.path %}
-    {% if options %}{% set entry = entry ~ ':' ~ options | join(',') %}{% endif %}
-    {% if entry not in podman_tmpfs.items %}{% set _ = podman_tmpfs.items.append(entry) %}{% endif %}
+    {% if existing is none %}
+      {% set existing = namespace(path=mount.path, options=[]) %}
+      {% set _ = podman_tmpfs.entries.append(existing) %}
+    {% endif %}
+    {% for flag in tmpfs_hardening_flags %}
+      {% if flag not in existing.options %}{% set _ = existing.options.append(flag) %}{% endif %}
+    {% endfor %}
+    {% if mount.size is defined %}
+      {% set size_flag = 'size=' ~ mount.size %}
+      {% if size_flag not in existing.options %}{% set _ = existing.options.append(size_flag) %}{% endif %}
+    {% endif %}
+    {% if mount.mode is defined %}
+      {% set mode_flag = 'mode=' ~ mount.mode %}
+      {% if mode_flag not in existing.options %}{% set _ = existing.options.append(mode_flag) %}{% endif %}
+    {% endif %}
   {% endif %}
 {% endfor %}
 {% set secret_env = secrets.env if secrets is defined and secrets.env is not none and secrets.env | length > 0 else [] %}
@@ -42,12 +56,13 @@
 {% set inline_env = service_env | default([]) %}
 {% set inline_env_names = inline_env | map(attribute='name') | list %}
 {% set resources = service_resources | default({}) %}
+{% set user_namespace = security.user_namespace if security.user_namespace is defined else none %}
 {% if resources.connections_per_second is defined %}
   {% set inline_env = inline_env + [{'name': 'CONNECTIONS_PER_SECOND', 'value': resources.connections_per_second | string}] %}
 {% endif %}
 {% set auto_update_mode = quadlet_auto_update | default('none') %}
 [Unit]
-Description={{ service_unit_description | default('Managed container for ' ~ (service_name | default(service_id))) }}
+Description={{ unit_description }}
 After=network-online.target
 Wants=network-online.target
 
@@ -61,6 +76,9 @@ NoNewPrivileges={{ 'true' if no_new_privs else 'false' }}
 {% for cap in drop_caps_default %}
 DropCapability={{ cap }}
 {% endfor %}
+{% if user_namespace is not none and (user_namespace | string) | length > 0 %}
+UserNS={{ user_namespace }}
+{% endif %}
 {% for env in inline_env %}
 Environment={{ env.name }}={{ env.value }}
 {% endfor %}
@@ -80,8 +98,10 @@ Volume={{ vol.source | default(vol.name) }}.volume:{{ vol.target }}:{% if vol.mo
 {% for secret in file_secrets %}
 Volume={{ secret_dir }}/{{ secret.name }}:{{ secret.target | default('/run/secrets/' ~ secret.name) }}:ro,Z
 {% endfor %}
-{% for entry in podman_tmpfs.items %}
-Tmpfs={{ entry }}
+{% for entry in podman_tmpfs.entries %}
+{% set tmpfs_value = entry.path %}
+{% if entry.options %}{% set tmpfs_value = tmpfs_value ~ ':' ~ entry.options | join(',') %}{% endif %}
+Tmpfs={{ tmpfs_value }}
 {% endfor %}
 {% for port in ports %}
 PublishPort={{ port.host_ip | default('') }}{% if port.host_ip is defined and port.host_ip | string | length > 0 %}:{% endif %}{{ port.published | default(port.target) }}:{{ port.target }}{% if port.protocol is defined %}/{{ port.protocol }}{% endif %}
@@ -97,8 +117,6 @@ TimeoutStartSec=900
 NoNewPrivileges={{ 'yes' if no_new_privs else 'no' }}
 {% if bounding_set %}
 CapabilityBoundingSet={{ bounding_set | join(' ') }}
-{% else %}
-CapabilityBoundingSet=
 {% endif %}
 
 [Install]


### PR DESCRIPTION
## Summary
- ensure the Podman quadlet template reads the service unit description, deduplicates tmpfs mounts, and adds support for UserNS
- avoid writing an empty CapabilityBoundingSet directive and document the new defaults
- extend the service schema to accept service_security.user_namespace

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f50581ff24832eb6af360436d9d8a9