### PR TITLE
Improve baremetal runtime systemd handling

### DIFF
--- a/roles/common/apply_runtime/tasks/baremetal.yml
+++ b/roles/common/apply_runtime/tasks/baremetal.yml
@@ -3,6 +3,14 @@
   set_fact:
     effective_service_unit_name: "{{ service_unit_name | default(service_id) }}"
 
+- name: Ensure systemd is the service manager
+  assert:
+    that:
+      - ansible_service_mgr is defined
+      - ansible_service_mgr == 'systemd'
+    fail_msg: "The target host does not use systemd as the service manager."
+    success_msg: "Systemd detected as the service manager."
+
 - name: Set service IP facts
   set_fact:
     service_ip: "{{ service_ip | default(ansible_default_ipv4.address) }}"
@@ -23,6 +31,7 @@
     dest: "{{ item.path }}"
     mode: "{{ item.mode | default('0644') }}"
     content: "{{ item.content }}"
+    unsafe_writes: false
   loop: "{{ service_files | default([]) }}"
   notify: Restart service
 
@@ -32,6 +41,27 @@
     src: "{{ runtime_config_path }}"
     dest: "/etc/systemd/system/{{ effective_service_unit_name }}.service"
     mode: '0644'
+    unsafe_writes: false
+  notify: Restart service
+
+- name: Ensure systemd drop-in directory exists
+  become: true
+  file:
+    path: "/etc/systemd/system/{{ effective_service_unit_name }}.service.d"
+    state: directory
+    mode: '0755'
+  when: service_drop_ins is defined and service_drop_ins | length > 0
+
+- name: Deploy systemd drop-in files
+  become: true
+  copy:
+    dest: "/etc/systemd/system/{{ effective_service_unit_name }}.service.d/{{ item.name }}"
+    mode: "{{ item.mode | default('0644') }}"
+    content: "{{ item.content | default(omit) }}"
+    src: "{{ item.src | default(omit) }}"
+    unsafe_writes: false
+  loop: "{{ service_drop_ins | default([]) }}"
+  when: service_drop_ins is defined and service_drop_ins | length > 0
   notify: Restart service
 
 - name: Reload systemd


### PR DESCRIPTION
## Summary
- assert that baremetal runtime tasks run only when systemd is the active service manager
- ensure service configuration and unit files are written using atomic copy operations
- add support for deploying systemd drop-in configuration files for services

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f505966c04832eaa71bfd57ce62e18