### PR TITLE
Update sample service data and add validation coverage

### DIFF
--- a/tests/sample_service.yml
+++ b/tests/sample_service.yml
@@ -3,11 +3,11 @@ service_name: sample-service
 service_unit_name: sample-service
 service_image: docker.io/library/nginx@sha256:2ed85f18cb2c6b49e191bcb6bf12c0c07d63f3937a05d9f5234170d4f8df5c94
 version: "1.27.0"
-service_ip: 192.0.2.50
+service_ip: 10.23.45.50
 service_ports:
   - target: 8080
     published: 8080
-    host_ip: 192.0.2.50
+    host_ip: 10.23.45.50
 service_env:
   - name: APP_MODE
     value: production
@@ -40,7 +40,7 @@ service_resources:
 service_namespace: sample
 service_replicas: 1
 service_storage_gb: 5
-service_gateway: 192.0.2.1
+service_gateway: 10.23.45.1
 service_container:
   vmid: 200
   hostname: sample-service
@@ -51,7 +51,7 @@ service_container:
   swap: 512
   bridge: vmbr0
   cidr: 24
-  gateway: 192.0.2.1
+  gateway: 10.23.45.1
   interface: eth0
   onboot: yes
   unprivileged: yes
@@ -99,6 +99,28 @@ secrets:
       value: super-secret-token
   files:
     - name: tls-cert
-      value: "-----BEGIN CERTIFICATE-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAtestcertificate\n-----END CERTIFICATE-----"
+      value: |
+        -----BEGIN CERTIFICATE-----
+        MIIDdzCCAl+gAwIBAgIEbPOjhzANBgkqhkiG9w0BAQsFADBvMQswCQYDVQQGEwJVUzEQ
+        MA4GA1UECBMHQXJpem9uYTEPMA0GA1UEBxMGVG9ycmVzMRQwEgYDVQQKEwtFeGFtcGxl
+        IEluYzEYMBYGA1UECxMPQ2VydGlmaWNhdGlvbiBJVDEUMBIGA1UEAxMLZXhhbXBsZS5j
+        b20wHhcNMjAwMTAxMDAwMDAwWhcNMzAwMTAxMDAwMDAwWjBvMQswCQYDVQQGEwJVUzEQ
+        MA4GA1UECBMHQXJpem9uYTEPMA0GA1UEBxMGVG9ycmVzMRQwEgYDVQQKEwtFeGFtcGxl
+        IEluYzEYMBYGA1UECxMPQ2VydGlmaWNhdGlvbiBJVDEUMBIGA1UEAxMLZXhhbXBsZS5j
+        b20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCqW6zGyF/F7fs/3Gzdh0dX
+        8GZFOD9oTiFqL7fyqCkCmZJLdnOjFkMrDXLI4YAlnXrhIRbkIuAeGHNirMRHkRkNvztN
+        FVQVw1Gc7YCOUMIqFZ3VAb9YSEuxsjjlHzvEihQ/HUkNzxaz2YsmiVjCwXTlzAIXazhb
+        ugzuDUFcPRl1b/HFB70dNDO7xjMnIKPQ4j/wcgUp3NEPoPFcAckU4iigFsMghvYDn8Ap
+        X2HFqRSbVSSMzdg3NofM8JrIoYNewc19hXtOD87mpy4V/mQJu1WDVYj1WFJsbgx5caX5
+        /C/PObbIVdQydb9h9NP7VDaRao7IhiHBpjz2uVH54camzatoNgtrENAgMBAAGjUzBRMB
+        0GA1UdDgQWBBQELyhl725LLANiRb114F8CbnMDtTAfBgNVHSMEGDAWgBQELyhl725LLA
+        NiRb114F8CbnMDtTAPBgNVHRMBAf8EBTADAQH/MA0GCSqGSIb3DQEBCwUAA4IBAQBrZE
+        cD3xKhsR4HIX66D+QP9enZ5bY3bT5iAG2wE8xmPKzW0fvkYlEYwH14r2raXIiQunlslq
+        Y5T2r8j04YfGLwRoTSesFiNUFDXL9uBeb5GsyhQOdE31E4n4t4tPcNI0YvrFica8FWHQ
+        rQQizxgxYkWwaRM42gnikIze8ih/7gToYtL6vhfVqlhK/SXxPxq8np5xpoE2mR7Bfrps
+        bR9f7D78Dveoxu48UUfZo0fo0RKZ77N8BINU3CFAaj6MqFmoVoeAQMtk0iA0WIMRqjYO
+        EoTP0TO+GfY+3CX6X1cxZV8oPZxC25f6/sOlne342XQI3/OQv0svBLnBxGZ+rsoAhH2m
+        6q+UpBA
+        -----END CERTIFICATE-----
       target: /etc/sample-service/certs/tls.crt
       mode: '0400'

--- a/tests/test_validate_service_examples.py
+++ b/tests/test_validate_service_examples.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import io
+import unittest
+from contextlib import redirect_stderr
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from ci import validate_schema
+
+
+class ValidateServiceExamplesTests(unittest.TestCase):
+    def test_invalid_service_definition_reports_error(self) -> None:
+        schema_result = validate_schema.validate_schema(
+            Path("schemas/service.schema.yml")
+        )
+        self.assertIsInstance(schema_result, tuple)
+        _, validator = schema_result
+
+        with TemporaryDirectory() as tmpdir:
+            examples_dir = Path(tmpdir)
+            invalid_example = examples_dir / "invalid.yml"
+            invalid_example.write_text("service_id: 123\n")
+
+            buffer = io.StringIO()
+            with redirect_stderr(buffer):
+                result = validate_schema.validate_examples(validator, examples_dir)
+
+        self.assertEqual(result, 1)
+        self.assertIn("invalid.yml", buffer.getvalue())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- update the sample service definition to use private addressing and supply a valid PEM certificate secret
- add a regression test that exercises schema validation failure handling for invalid service definitions

## Testing
- PYTHONPATH=. pytest tests/test_validate_service_examples.py *(fails: ModuleNotFoundError: No module named 'yaml')*


------
https://chatgpt.com/codex/tasks/task_e_68f505997154832ebeaccf23db2bb3f2