### PR TITLE
Align documentation with runtime behaviour

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -2,6 +2,8 @@
 
 A runtime-agnostic infrastructure-as-code framework for deploying self-hosted applications across **Proxmox LXC**, **Docker Compose**, **Podman Quadlets**, **Kubernetes**, and **bare-metal systemd** from a single service contract.
 
+> **Heads-up:** Earlier drafts referenced an "Advanced Research mode". That experiment has been retired—everything documented here reflects the only supported workflow.
+
 ## Key Features
 
 - **Write Once, Deploy Anywhere** – render the same service definition into runtime-specific manifests and unit files.
@@ -53,7 +55,9 @@ The rendered manifest is written to `/tmp/ansible-runtime/<service_id>/<runtime>
 
 ## Service Contract Essentials
 
-Every service definition must provide identifiers, runtime templates, health checks, mounts, and exports. A minimal example using the bundled `sample_service.yml` looks like:
+Every service definition must provide identifiers, runtime templates, health checks, mounts, and exports. Host mounts **must** be declared with the `service_volumes` key (plural) to match the live schema.
+
+A minimal example using the bundled `sample_service.yml` looks like:
 
 ```yaml
 service_id: sample-service
@@ -97,7 +101,7 @@ secrets:
       value: "{{ sample_service_tls_cert }}"
 ```
 
-> **Note:** Always declare host mounts with `service_volumes` (plural). The legacy `service_volume` key has been removed; migrate older inventories to the plural form before running validation.
+> **Note:** Always declare host mounts with `service_volumes` (plural). The legacy `service_volume` key has been removed from the framework; migrate older inventories to the plural form before running validation to avoid schema failures.
 
 Downstream applications consume these exports by resolving them through a dependency registry shared between repositories. Provide the registry as a list of known dependencies either inline (`dependency_registry`) or via `dependency_registry_file`:
 

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -4,7 +4,7 @@ Deploy services using Docker Compose with secret-aware environment injection and
 
 ## What's new
 
-- Secrets defined in the service contract travel via the Compose CLI environment so sensitive values never touch disk.
+- Secrets defined in the service contract travel via the Compose CLI environment. Values are staged on disk during deployment and shredded afterward when `secrets.shred_after_apply` remains `true`.
 - File-based secrets render into `secrets/` and are attached via Compose `secrets` blocks.
 - `community.docker.docker_compose_v2` drives deployments to align with the modern Docker CLI plugin.
 - Health probes come directly from `health.cmd` ensuring parity with other runtimes.

--- a/docs/edge.md
+++ b/docs/edge.md
@@ -87,6 +87,8 @@ the edge configuration is correct.
 
 ## Roles
 
+> **Note:** There is no standalone `edge_proxy_nginx` role. Nginx automation is provided through the OPNsense plugin via `edge_opnsense_nginx`.
+
 ### `edge_ingress`
 
 Normalises the ingress contract for all downstream roles. It validates the

--- a/docs/kubernetes.md
+++ b/docs/kubernetes.md
@@ -118,6 +118,7 @@ kubectl apply --dry-run=client --validate=true -f /tmp/ansible-runtime/sample-se
 ## Deployment tips
 
 - Ensure the referenced namespace (`k8s_namespace`) exists before applying.
+- Verify that your CNI implementation enforces `NetworkPolicy` (for example Calico, Cilium, or kube-router) and author ingress/egress policies alongside the rendered manifests when workloads require isolation.
 - Use the generated `<service_id>-files` Secret for only the workloads that truly need those files; other deployments can skip mounting the `secret-files` volume entirely.
 - Adjust `service_replicas` to scale deployments and rely on the readiness probe before routing traffic.
 - Confirm etcd encryption at rest is enabled (`kubectl get apiserver cluster -o jsonpath='{.spec.encryptionConfiguration}'`) before applying rendered Secrets; otherwise, configure encryption providers or document the risk for operators.

--- a/docs/podman.md
+++ b/docs/podman.md
@@ -72,7 +72,7 @@ CapabilityBoundingSet=
 WantedBy=multi-user.target default.target
 ```
 
-For `quadlet_scope: user`, the environment file and secrets live under `~/.config/containers/systemd/`. Enable lingering or ensure user services start at boot so the unit remains active.
+For `quadlet_scope: user`, the `.container` unit and environment file live under `~/.config/containers/systemd/`, while secret files are staged in `~/.config/containers/systemd/secrets/`. Enable lingering or ensure user services start at boot so the unit remains active.
 
 ## Deployment workflow
 


### PR DESCRIPTION
## Summary
- clarify that the framework only supports the documented workflow and that host mounts must use the `service_volumes` key
- document Docker secret staging, remove the non-existent edge_proxy_nginx role reference, and correct Podman user-scope paths
- call out Kubernetes NetworkPolicy requirements so operators enforce segmentation

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f5059db320832ead01d687af563334