### PR TITLE
Add restart controls and syscall filtering to bare-metal template

### DIFF
--- a/ci/__init__.py
+++ b/ci/__init__.py
@@ -1,0 +1,1 @@
+"""Utilities for CI validation tasks."""

--- a/docs/baremetal.md
+++ b/docs/baremetal.md
@@ -9,6 +9,8 @@ Deploy services directly on bare-metal or virtual machines with idempotent confi
 - Generated units inherit defaults from `templates/baremetal.yml.j2`, keeping runtime-agnostic settings consistent.
 - `mounts.ephemeral_mounts` entries render `TemporaryFileSystem=` directives so only the declared paths stay writable at runtime.
 - systemd units enable `PrivateTmp=yes`, `ProtectSystem=strict`, and `ProtectHome=yes` by default (unless overridden via `service_security`) to harden the host.
+- Optional restart policies (`service_restart`) add directives such as `RestartSec=` without overriding explicit unit overrides.
+- `service_security.system_call_filter` renders `SystemCallFilter=` for additional system call hardening.
 
 ## Prerequisites
 

--- a/schemas/service.schema.yml
+++ b/schemas/service.schema.yml
@@ -352,6 +352,41 @@ properties:
         oneOf:
           - type: boolean
           - type: string
+      system_call_filter:
+        oneOf:
+          - type: string
+          - type: array
+            items:
+              type: string
+  service_restart:
+    type: object
+    properties:
+      restart:
+        type: string
+      restart_sec:
+        type: string
+      restart_max_delay_sec:
+        type: string
+      restart_timeout_sec:
+        type: string
+      restart_prevent_exit_status:
+        oneOf:
+          - type: string
+          - type: array
+            items:
+              type: string
+      restart_force_exit_status:
+        oneOf:
+          - type: string
+          - type: array
+            items:
+              type: string
+      start_limit_interval_sec:
+        type: string
+      start_limit_burst:
+        type: integer
+      start_limit_action:
+        type: string
   kubernetes:
     type: object
     properties:

--- a/templates/baremetal.yml.j2
+++ b/templates/baremetal.yml.j2
@@ -4,6 +4,7 @@
 {% set service_section = unit.service | default({'Type': 'simple', 'ExecStart': '/usr/bin/true'}) %}
 {% set install_targets = unit.install_wanted_by | default(['multi-user.target']) %}
 {% set security = service_security | default({}) %}
+{% set restart_config = service_restart | default({}) %}
 {% set mounts_config = mounts | default({}) %}
 {% set ephemeral_mounts = mounts_config.ephemeral_mounts | default([]) %}
 {% set default_apply_targets = ['docker', 'podman', 'kubernetes', 'proxmox', 'baremetal'] %}
@@ -17,24 +18,25 @@
     {% set _ = baremetal_tmpfs.items.append({'path': mount.path, 'options': options}) %}
   {% endif %}
 {% endfor %}
+{% macro systemd_toggle(value, true_value='yes', false_value='no') -%}
+  {%- if value is boolean -%}
+    {{ true_value if value else false_value }}
+  {%- else -%}
+    {{ value }}
+  {%- endif -%}
+{%- endmacro %}
 {% set read_only_root = security.read_only_root_filesystem if security.read_only_root_filesystem is defined else true %}
 {% set private_tmp_default = security.private_tmp if security.private_tmp is defined else true %}
 {% set protect_system_default = security.protect_system if security.protect_system is defined else (read_only_root | ternary('strict', 'full')) %}
 {% set protect_home_default = security.protect_home if security.protect_home is defined else 'yes' %}
-{% if protect_home_default is boolean %}
-  {% set protect_home_value = protect_home_default | ternary('yes', 'no') %}
+{% set protect_home_value = systemd_toggle(protect_home_default, 'yes', 'no') %}
+{% set private_tmp_value = systemd_toggle(private_tmp_default, 'yes', 'no') %}
+{% set protect_system_value = systemd_toggle(protect_system_default, 'strict', 'no') %}
+{% set system_call_filter = security.system_call_filter if security.system_call_filter is defined else none %}
+{% if system_call_filter is sequence and system_call_filter is not string %}
+  {% set system_call_filter_value = system_call_filter | map('string') | join(' ') %}
 {% else %}
-  {% set protect_home_value = protect_home_default %}
-{% endif %}
-{% if private_tmp_default is boolean %}
-  {% set private_tmp_value = private_tmp_default | ternary('yes', 'no') %}
-{% else %}
-  {% set private_tmp_value = private_tmp_default %}
-{% endif %}
-{% if protect_system_default is boolean %}
-  {% set protect_system_value = protect_system_default | ternary('strict', 'no') %}
-{% else %}
-  {% set protect_system_value = protect_system_default %}
+  {% set system_call_filter_value = system_call_filter %}
 {% endif %}
 
 [Unit]
@@ -56,6 +58,31 @@ ProtectSystem={{ protect_system_value }}
 {% if 'ProtectHome' not in service_section %}
 ProtectHome={{ protect_home_value }}
 {% endif %}
+{% if system_call_filter_value %}
+  {% if 'SystemCallFilter' not in service_section %}
+SystemCallFilter={{ system_call_filter_value }}
+  {% endif %}
+{% endif %}
+{% set restart_directives = [
+  ('Restart', restart_config.restart if restart_config.restart is defined else none),
+  ('RestartSec', restart_config.restart_sec if restart_config.restart_sec is defined else none),
+  ('RestartMaxDelaySec', restart_config.restart_max_delay_sec if restart_config.restart_max_delay_sec is defined else none),
+  ('RestartTimeoutSec', restart_config.restart_timeout_sec if restart_config.restart_timeout_sec is defined else none),
+  ('RestartPreventExitStatus', restart_config.restart_prevent_exit_status if restart_config.restart_prevent_exit_status is defined else none),
+  ('RestartForceExitStatus', restart_config.restart_force_exit_status if restart_config.restart_force_exit_status is defined else none),
+  ('StartLimitIntervalSec', restart_config.start_limit_interval_sec if restart_config.start_limit_interval_sec is defined else none),
+  ('StartLimitBurst', restart_config.start_limit_burst if restart_config.start_limit_burst is defined else none),
+  ('StartLimitAction', restart_config.start_limit_action if restart_config.start_limit_action is defined else none)
+] %}
+{% for directive, value in restart_directives %}
+  {% if value is not none and directive not in service_section %}
+    {% if value is sequence and value is not string %}
+{{ directive }}={{ value | join(' ') }}
+    {% else %}
+{{ directive }}={{ value }}
+    {% endif %}
+  {% endif %}
+{% endfor %}
 {% if baremetal_tmpfs.items %}
 {% for mount in baremetal_tmpfs.items %}
 TemporaryFileSystem={{ mount.path }}{% if mount.options %}:{{ mount.options | join(',') }}{% endif %}

--- a/tests/test_baremetal_template.py
+++ b/tests/test_baremetal_template.py
@@ -1,0 +1,81 @@
+import textwrap
+from pathlib import Path
+
+import pytest
+
+jinja2 = pytest.importorskip("jinja2")
+Environment = jinja2.Environment
+FileSystemLoader = jinja2.FileSystemLoader
+
+
+TEMPLATE_DIR = Path("templates")
+TEMPLATE_NAME = "baremetal.yml.j2"
+
+
+def render_baremetal(**overrides: object) -> str:
+    env = Environment(
+        loader=FileSystemLoader(str(TEMPLATE_DIR)),
+        trim_blocks=True,
+        lstrip_blocks=True,
+    )
+    template = env.get_template(TEMPLATE_NAME)
+
+    context: dict[str, object] = {
+        "service_id": "sample-service",
+        "service_name": "sample-service",
+        "service_unit": {},
+        "service_security": {},
+        "mounts": {},
+    }
+    context.update(overrides)
+    rendered = template.render(**context)
+    return textwrap.dedent(rendered).strip()
+
+
+def test_system_call_filter_sequence_renders() -> None:
+    rendered = render_baremetal(
+        service_security={
+            "system_call_filter": ["~clone", "@system-service"],
+        }
+    )
+
+    assert "SystemCallFilter=~clone @system-service" in rendered
+
+
+def test_restart_parameters_apply_defaults() -> None:
+    rendered = render_baremetal(
+        service_restart={
+            "restart": "on-failure",
+            "restart_sec": "5s",
+            "restart_prevent_exit_status": ["SIGKILL", "SIGTERM"],
+            "start_limit_burst": 5,
+        }
+    )
+
+    assert "Restart=on-failure" in rendered
+    assert "RestartSec=5s" in rendered
+    assert "RestartPreventExitStatus=SIGKILL SIGTERM" in rendered
+    assert "StartLimitBurst=5" in rendered
+
+
+def test_service_section_override_skips_restart_defaults() -> None:
+    rendered = render_baremetal(
+        service_restart={"restart": "on-failure"},
+        service_unit={"service": {"Restart": "always"}},
+    )
+
+    service_lines = [
+        line.strip() for line in rendered.splitlines() if line.startswith("Restart=")
+    ]
+
+    assert service_lines == ["Restart=always"]
+
+
+def test_protect_home_boolean_converts_to_yes() -> None:
+    rendered = render_baremetal(
+        service_security={
+            "protect_home": True,
+        }
+    )
+
+    assert "ProtectHome=yes" in rendered

--- a/tests/test_validate_proxmox_manifest.py
+++ b/tests/test_validate_proxmox_manifest.py
@@ -2,10 +2,15 @@ from __future__ import annotations
 
 import io
 import json
+import sys
 import unittest
 from contextlib import redirect_stderr, redirect_stdout
 from pathlib import Path
 from tempfile import TemporaryDirectory
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
 
 from ci import validate_proxmox_manifest as proxmox_validator
 


### PR DESCRIPTION
## Summary
- add restart configuration support and system call filtering to the bare-metal systemd template while simplifying boolean handling
- extend the service schema and documentation for the new security and restart options
- add unit tests for the template and ensure CI helpers are importable

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68f50592192c832eaff6b9a66201ea5e