### PR TITLE
Refactor runtime templates to use shared filters

### DIFF
--- a/filter_plugins/health.py
+++ b/filter_plugins/health.py
@@ -2,10 +2,13 @@
 
 from __future__ import annotations
 
-from typing import Any, Iterable, List
+from typing import Any, Iterable, List, Mapping
 
 
 DEFAULT_COMMAND = ["true"]
+DEFAULT_INTERVAL = "10s"
+DEFAULT_TIMEOUT = "5s"
+DEFAULT_RETRIES = 3
 
 
 def get_health_command(health: Any | None) -> List[str]:
@@ -46,8 +49,69 @@ def get_health_command(health: Any | None) -> List[str]:
     return [str(arg) for arg in command]
 
 
+def _get_value(source: Any | None, key: str, default: Any) -> Any:
+    if not source:
+        return default
+
+    if isinstance(source, Mapping):
+        return source.get(key, default)
+
+    return getattr(source, key, default)
+
+
+def _duration_to_seconds(value: Any, default: Any) -> int:
+    value = value if value is not None else default
+
+    if isinstance(value, (int, float)):
+        return int(value)
+
+    if not value:
+        return int(default)
+
+    text = str(value).strip().lower()
+    multiplier = 1
+
+    if text.endswith("ms"):
+        multiplier = 0.001
+        text = text[:-2]
+    elif text.endswith("s"):
+        text = text[:-1]
+    elif text.endswith("m"):
+        multiplier = 60
+        text = text[:-1]
+
+    try:
+        return int(float(text) * multiplier)
+    except (TypeError, ValueError):
+        return int(default)
+
+
+def normalize_health(health: Any | None) -> dict[str, Any]:
+    interval = _get_value(health, "interval", DEFAULT_INTERVAL)
+    timeout = _get_value(health, "timeout", DEFAULT_TIMEOUT)
+    retries = _get_value(health, "retries", DEFAULT_RETRIES)
+    start_period = _get_value(health, "start_period", None)
+
+    interval_value = DEFAULT_INTERVAL if interval is None else interval
+    timeout_value = DEFAULT_TIMEOUT if timeout is None else timeout
+
+    return {
+        "command": get_health_command(health),
+        "interval": str(interval_value),
+        "timeout": str(timeout_value),
+        "retries": int(retries if retries is not None else DEFAULT_RETRIES),
+        "start_period": start_period,
+        "interval_seconds": _duration_to_seconds(interval, DEFAULT_INTERVAL),
+        "timeout_seconds": _duration_to_seconds(timeout, DEFAULT_TIMEOUT),
+    }
+
+
 def health_command_filter(health: Any | None) -> List[str]:
     return get_health_command(health)
+
+
+def normalize_health_filter(health: Any | None) -> dict[str, Any]:
+    return normalize_health(health)
 
 
 class FilterModule:
@@ -56,4 +120,5 @@ class FilterModule:
     def filters(self) -> dict[str, Any]:
         return {
             "health_command": health_command_filter,
+            "normalize_health": normalize_health_filter,
         }

--- a/filter_plugins/runtime.py
+++ b/filter_plugins/runtime.py
@@ -1,0 +1,158 @@
+"""Runtime helpers shared across service templates."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+from typing import Any
+
+
+DEFAULT_APPLY_TARGETS = [
+    "docker",
+    "podman",
+    "kubernetes",
+    "proxmox",
+    "baremetal",
+]
+
+
+def _get_value(source: Any | None, key: str, default: Any) -> Any:
+    if source is None:
+        return default
+
+    if isinstance(source, Mapping):
+        return source.get(key, default)
+
+    return getattr(source, key, default)
+
+
+def _as_iterable(value: Any | None) -> list[Any]:
+    if value is None:
+        return []
+
+    if isinstance(value, str):
+        return [value]
+
+    if isinstance(value, Iterable):
+        return list(value)
+
+    return [value]
+
+
+def normalize_security(service_security: Any | None) -> dict[str, Any]:
+    run_user = int(_get_value(service_security, "run_as_user", 65532))
+    run_group = int(_get_value(service_security, "run_as_group", run_user))
+    read_only_root = bool(
+        _get_value(service_security, "read_only_root_filesystem", True)
+    )
+    no_new_privs = bool(_get_value(service_security, "no_new_privileges", True))
+
+    allow_priv = _get_value(service_security, "allow_privilege_escalation", None)
+    if allow_priv is None:
+        allow_priv = not no_new_privs
+    else:
+        allow_priv = bool(allow_priv)
+
+    drop_caps = [
+        str(cap)
+        for cap in _as_iterable(
+            _get_value(service_security, "capabilities_drop", ["ALL"])
+        )
+    ]
+    compose_user = _get_value(service_security, "user", f"{run_user}:{run_group}")
+    apparmor = _get_value(service_security, "apparmor_profile", "docker-default")
+    bounding = [
+        str(cap)
+        for cap in _as_iterable(
+            _get_value(service_security, "capability_bounding_set", [])
+        )
+    ]
+
+    return {
+        "run_as_user": run_user,
+        "run_as_group": run_group,
+        "read_only_root_filesystem": read_only_root,
+        "allow_privilege_escalation": allow_priv,
+        "no_new_privileges": no_new_privs,
+        "capabilities_drop": drop_caps,
+        "compose_user": compose_user,
+        "apparmor_profile": apparmor,
+        "capability_bounding_set": bounding,
+    }
+
+
+def select_mounts(
+    mounts: Any | None, target: str, default_targets: Iterable[str] | None = None
+) -> list[dict[str, Any]]:
+    if not mounts:
+        return []
+
+    selected: list[dict[str, Any]] = []
+    default_targets = list(default_targets or DEFAULT_APPLY_TARGETS)
+
+    for raw in mounts:
+        if isinstance(raw, Mapping):
+            apply_to = raw.get("apply_to", default_targets)
+            if target not in _as_iterable(apply_to):
+                continue
+            selected.append(dict(raw))
+            continue
+
+        apply_to = getattr(raw, "apply_to", default_targets)
+        if target in _as_iterable(apply_to):
+            selected.append(dict(raw.__dict__))
+
+    return selected
+
+
+def normalize_secrets(secrets: Any | None, service_name: str) -> dict[str, Any]:
+    env_items = _as_iterable(_get_value(secrets, "env", []))
+    file_items = _as_iterable(_get_value(secrets, "files", []))
+    rotation = _get_value(secrets, "rotation_timestamp", None)
+
+    return {
+        "env": env_items,
+        "files": file_items,
+        "has_env": len(env_items) > 0,
+        "has_files": len(file_items) > 0,
+        "env_secret_name": f"{service_name}-env",
+        "file_secret_name": f"{service_name}-files",
+        "rotation_timestamp": rotation,
+    }
+
+
+def merge_environment(
+    inline_env: Iterable[Mapping[str, Any]] | None,
+    extra: Iterable[Mapping[str, Any]] | None = None,
+) -> dict[str, Any]:
+    items: list[dict[str, Any]] = []
+    names: list[str] = []
+
+    def _append(entry: Mapping[str, Any]) -> None:
+        name = str(entry.get("name", "")).strip()
+        if not name or name in names:
+            return
+
+        items.append({"name": name, "value": str(entry.get("value", ""))})
+        names.append(name)
+
+    for source in (inline_env, extra):
+        if not source:
+            continue
+
+        for entry in source:
+            if isinstance(entry, Mapping):
+                _append(entry)
+
+    return {"items": items, "names": names}
+
+
+class FilterModule:
+    """Expose runtime helpers to Ansible."""
+
+    def filters(self) -> dict[str, Any]:
+        return {
+            "normalize_security": normalize_security,
+            "select_mounts": select_mounts,
+            "normalize_secrets": normalize_secrets,
+            "merge_environment": merge_environment,
+        }

--- a/templates/baremetal.yml.j2
+++ b/templates/baremetal.yml.j2
@@ -3,21 +3,17 @@
 {% set after = unit.after | default(['network.target']) %}
 {% set service_section = unit.service | default({'Type': 'simple', 'ExecStart': '/usr/bin/true'}) %}
 {% set install_targets = unit.install_wanted_by | default(['multi-user.target']) %}
-{% set security = service_security | default({}) %}
+{% set security_defaults = (service_security if service_security is defined else None) | normalize_security %}
 {% set mounts_config = mounts | default({}) %}
 {% set ephemeral_mounts = mounts_config.ephemeral_mounts | default([]) %}
-{% set default_apply_targets = ['docker', 'podman', 'kubernetes', 'proxmox', 'baremetal'] %}
 {% set baremetal_tmpfs = namespace(items=[]) %}
-{% for mount in ephemeral_mounts %}
-  {% set apply_targets = mount.apply_to | default(default_apply_targets) %}
-  {% if 'baremetal' in apply_targets %}
-    {% set options = [] %}
-    {% if mount.size is defined %}{% set _ = options.append('size=' ~ mount.size) %}{% endif %}
-    {% if mount.mode is defined %}{% set _ = options.append('mode=' ~ mount.mode) %}{% endif %}
-    {% set _ = baremetal_tmpfs.items.append({'path': mount.path, 'options': options}) %}
-  {% endif %}
+{% for mount in ephemeral_mounts | select_mounts('baremetal') %}
+  {% set options = [] %}
+  {% if mount.size is defined %}{% set _ = options.append('size=' ~ mount.size) %}{% endif %}
+  {% if mount.mode is defined %}{% set _ = options.append('mode=' ~ mount.mode) %}{% endif %}
+  {% set _ = baremetal_tmpfs.items.append({'path': mount.path, 'options': options}) %}
 {% endfor %}
-{% set read_only_root = security.read_only_root_filesystem if security.read_only_root_filesystem is defined else true %}
+{% set read_only_root = security_defaults.read_only_root_filesystem %}
 {% set private_tmp_default = security.private_tmp if security.private_tmp is defined else true %}
 {% set protect_system_default = security.protect_system if security.protect_system is defined else (read_only_root | ternary('strict', 'full')) %}
 {% set protect_home_default = security.protect_home if security.protect_home is defined else 'yes' %}

--- a/templates/docker.yml.j2
+++ b/templates/docker.yml.j2
@@ -1,19 +1,15 @@
 {%- set mounts_config = mounts | default({}) %}
 {%- set ephemeral_mounts = mounts_config.ephemeral_mounts | default([]) %}
-{%- set default_apply_targets = ['docker', 'podman', 'kubernetes', 'proxmox', 'baremetal'] %}
-{%- set security = service_security | default({}) %}
-{%- set default_run_user = security.run_as_user if security.run_as_user is defined else 65532 %}
-{%- set default_run_group = security.run_as_group if security.run_as_group is defined else default_run_user %}
-{%- set compose_user_default = security.user if security.user is defined else ((default_run_user | string) ~ ':' ~ (default_run_group | string)) %}
-{%- set read_only_root = security.read_only_root_filesystem if security.read_only_root_filesystem is defined else true %}
-{%- set drop_caps_default = security.capabilities_drop | default(['ALL']) %}
-{%- if drop_caps_default is string %}{%- set drop_caps_default = [drop_caps_default] %}{%- endif %}
-{%- set no_new_privs = security.no_new_privileges if security.no_new_privileges is defined else true %}
-{%- set default_apparmor = security.apparmor_profile if security.apparmor_profile is defined else 'docker-default' %}
+{%- set security_defaults = (service_security if service_security is defined else None) | normalize_security %}
+{%- set default_run_user = security_defaults.run_as_user %}
+{%- set default_run_group = security_defaults.run_as_group %}
+{%- set compose_user_default = security_defaults.compose_user %}
+{%- set read_only_root = security_defaults.read_only_root_filesystem %}
+{%- set drop_caps_default = security_defaults.capabilities_drop %}
+{%- set no_new_privs = security_defaults.no_new_privileges %}
+{%- set default_apparmor = security_defaults.apparmor_profile %}
 {%- set docker_tmpfs = namespace(items=[]) %}
-{%- for mount in ephemeral_mounts %}
-  {%- set apply_targets = mount.apply_to | default(default_apply_targets) %}
-  {%- if 'docker' in apply_targets %}
+{%- for mount in ephemeral_mounts | select_mounts('docker') %}
     {%- set options = [] %}
     {%- if mount.size is defined %}{%- set _ = options.append('size=' ~ mount.size) %}{%- endif %}
     {%- if mount.mode is defined %}{%- set _ = options.append('mode=' ~ mount.mode) %}{%- endif %}
@@ -34,8 +30,10 @@
 {% set resources = service_resources | default({}) %}
 {% set connections_per_second = resources.connections_per_second if resources.connections_per_second is defined else None %}
 {% set primary_service_name = service_name | default(service_id) %}
-{% set secret_env = secrets.env if secrets is defined and secrets.env is not none and secrets.env | length > 0 else [] %}
-{% set file_secrets = secrets.files if secrets is defined and secrets.files is not none and secrets.files | length > 0 else [] %}
+{% set secrets_info = (secrets if secrets is defined else None) | normalize_secrets(primary_service_name) %}
+{% set secret_env = secrets_info.env %}
+{% set file_secrets = secrets_info.files %}
+{% set secrets_rotation = secrets_info.rotation_timestamp %}
 services:
 {% for svc in services_list %}
   {%- set svc_user = svc.user if svc.user is defined else compose_user_default %}
@@ -133,36 +131,28 @@ services:
 {% endfor %}
 {% endif %}
 {% set inline_env = svc.env | default([]) %}
-
-{% set environment_ns = namespace(items=[], names=[]) %}
-
+{% set env_extras = [] %}
 {% if connections_per_second and svc.name == primary_service_name %}
-  {% set inline_env = inline_env + [{'name': 'CONNECTIONS_PER_SECOND', 'value': connections_per_second | string}] %}
+  {% set _ = env_extras.append({'name': 'CONNECTIONS_PER_SECOND', 'value': connections_per_second | string}) %}
 {% endif %}
-  {% for item in inline_env %}
-    {% if item.name not in environment_ns.names %}
-      {% set _ = environment_ns.items.append({'name': item.name, 'value': item.value}) %}
-      {% set _ = environment_ns.names.append(item.name) %}
-    {% endif %}
-  {% endfor %}
-  {% if secrets is defined and secrets.rotation_timestamp is defined and secrets.rotation_timestamp is not none %}
-    {% if 'SHMA_SECRETS_ROTATION' not in environment_ns.names %}
-      {% set _ = environment_ns.items.append({'name': 'SHMA_SECRETS_ROTATION', 'value': secrets.rotation_timestamp}) %}
-      {% set _ = environment_ns.names.append('SHMA_SECRETS_ROTATION') %}
-    {% endif %}
+{% if secrets_rotation is not none %}
+  {% set _ = env_extras.append({'name': 'SHMA_SECRETS_ROTATION', 'value': secrets_rotation}) %}
+{% endif %}
+{% set env_data = inline_env | merge_environment(env_extras) %}
+{% set env_items = env_data.items %}
+{% set env_names = env_data.names %}
+{% for secret_item in svc_secret_env %}
+  {% if secret_item.name not in env_names %}
+    {% set _ = env_items.append({'name': secret_item.name, 'value': '${' ~ secret_item.name ~ '}'}) %}
+    {% set _ = env_names.append(secret_item.name) %}
   {% endif %}
-  {% for secret_item in svc_secret_env %}
-    {% if secret_item.name not in environment_ns.names %}
-      {% set _ = environment_ns.items.append({'name': secret_item.name, 'value': '${' ~ secret_item.name ~ '}'}) %}
-      {% set _ = environment_ns.names.append(secret_item.name) %}
-    {% endif %}
-  {% endfor %}
-  {% if environment_ns.items %}
+{% endfor %}
+{% if env_items %}
     environment:
-  {% for env_item in environment_ns.items %}
+{% for env_item in env_items %}
       {{ env_item.name }}: {{ env_item.value }}
-  {% endfor %}
-  {% endif %}
+{% endfor %}
+{% endif %}
   {% if svc.entrypoint is defined %}
     entrypoint: {{ svc.entrypoint if svc.entrypoint is string else svc.entrypoint | to_json }}
 {% endif %}
@@ -225,14 +215,15 @@ services:
     deploy:
 {{ svc.deploy | to_nice_yaml(indent=6) | indent(6) }}
 {% endif %}
-{% set svc_health = svc.health if svc.health is defined else (health if loop.first and health is defined else None) %}
-{% if svc_health is not none %}
+{% set svc_health_source = svc.health if svc.health is defined else (health if loop.first and health is defined else None) %}
+{% if svc_health_source is not none %}
+  {% set svc_health = svc_health_source | normalize_health %}
     healthcheck:
-      test: {{ svc_health.cmd | default(['true']) | to_json }}
-      interval: {{ svc_health.interval | default('10s') }}
-      timeout: {{ svc_health.timeout | default('5s') }}
-      retries: {{ svc_health.retries | default(3) }}
-{% if svc_health.start_period is defined %}
+      test: {{ svc_health.command | to_json }}
+      interval: {{ svc_health.interval }}
+      timeout: {{ svc_health.timeout }}
+      retries: {{ svc_health.retries }}
+{% if svc_health.start_period is not none %}
       start_period: {{ svc_health.start_period }}
 {% endif %}
 {% endif %}

--- a/templates/kubernetes.yml.j2
+++ b/templates/kubernetes.yml.j2
@@ -3,52 +3,56 @@
 {% set svc_namespace = service_namespace | default('default') %}
 {% set mounts_config = mounts | default({}) %}
 {% set ephemeral_mounts = mounts_config.ephemeral_mounts | default([]) %}
-{% set default_apply_targets = ['docker', 'podman', 'kubernetes', 'proxmox', 'baremetal'] %}
-{% set security = service_security | default({}) %}
-{% set default_run_user = security.run_as_user if security.run_as_user is defined else 65532 %}
-{% set default_run_group = security.run_as_group if security.run_as_group is defined else default_run_user %}
-{% set read_only_root = security.read_only_root_filesystem if security.read_only_root_filesystem is defined else true %}
-{% set drop_caps_default = security.capabilities_drop | default(['ALL']) %}
-{% if drop_caps_default is string %}{% set drop_caps_default = [drop_caps_default] %}{% endif %}
-{% set no_new_privs = security.no_new_privileges if security.no_new_privileges is defined else true %}
-{% set allow_priv_escalation = security.allow_privilege_escalation if security.allow_privilege_escalation is defined else (not no_new_privs) %}
+{% set security_defaults = (service_security if service_security is defined else None) | normalize_security %}
+{% set default_run_user = security_defaults.run_as_user %}
+{% set default_run_group = security_defaults.run_as_group %}
+{% set read_only_root = security_defaults.read_only_root_filesystem %}
+{% set drop_caps_default = security_defaults.capabilities_drop %}
+{% set no_new_privs = security_defaults.no_new_privileges %}
+{% set allow_priv_escalation = security_defaults.allow_privilege_escalation %}
+{% set health_defaults = (health if health is defined else None) | normalize_health %}
 {% set ingress_spec = ingress | default({}) %}
 {% set ingress_routes = ingress_spec.routes | default([]) %}
 {% set ingress_flag = ingress_spec.get('enabled') if ingress_spec is mapping else none %}
 {% set ingress_enabled = (ingress_flag if ingress_flag is not none else (ingress_routes | length > 0)) %}
 {% set k8s_ephemeral = namespace(items=[]) %}
-{% for mount in ephemeral_mounts %}
-  {% set apply_targets = mount.apply_to | default(default_apply_targets) %}
-  {% if 'kubernetes' in apply_targets %}
-    {% set volume_name = mount.name | default('ephemeral-' ~ loop.index) %}
-    {% set entry = {
-      'volume_name': volume_name,
-      'mount_path': mount.path,
-      'medium': mount.medium | default('Memory'),
-      'size': mount.size if mount.size is defined else None,
-      'read_only': mount.read_only if mount.read_only is defined else false
-    } %}
-    {% set _ = k8s_ephemeral.items.append(entry) %}
-  {% endif %}
+{% for mount in ephemeral_mounts | select_mounts('kubernetes') %}
+  {% set volume_name = mount.name | default('ephemeral-' ~ loop.index) %}
+  {% set entry = {
+    'volume_name': volume_name,
+    'mount_path': mount.path,
+    'medium': mount.medium | default('Memory'),
+    'size': mount.size if mount.size is defined else None,
+    'read_only': mount.read_only if mount.read_only is defined else false
+  } %}
+  {% set _ = k8s_ephemeral.items.append(entry) %}
 {% endfor %}
-{% set secret_env = secrets.env if secrets is defined and secrets.env is not none and secrets.env | length > 0 else [] %}
-{% set file_secrets = secrets.files if secrets is defined and secrets.files is not none and secrets.files | length > 0 else [] %}
-{% set inline_env = service_env | default([]) | list %}
-{% set inline_env_ns = namespace(items=inline_env) %}
-{% set env_secret_name = svc_name + '-env' %}
-{% set file_secret_name = svc_name + '-files' %}
-{% set health_cmd = health.cmd | default(['true']) %}
-{% set health_interval_seconds = (health.interval | default('10s')) | regex_replace('s$', '') | int %}
-{% set health_timeout_seconds = (health.timeout | default('5s')) | regex_replace('s$', '') | int %}
-{% set health_retries = health.retries | default(3) %}
+{% set secrets_info = (secrets if secrets is defined else None) | normalize_secrets(svc_name) %}
+{% set secret_env = secrets_info.env %}
+{% set file_secrets = secrets_info.files %}
+{% set env_secret_name = secrets_info.env_secret_name %}
+{% set file_secret_name = secrets_info.file_secret_name %}
+{% set inline_env = service_env | default([]) %}
+{% set env_extras = [] %}
+{% if secrets_info.rotation_timestamp is not none %}
+  {% set _ = env_extras.append({'name': 'SHMA_SECRETS_ROTATION', 'value': secrets_info.rotation_timestamp | string}) %}
+{% endif %}
+{% set resources = service_resources | default({'memory_mb': 256, 'cpu_cores': 1}) %}
+{% if resources.connections_per_second is defined %}
+  {% set _ = env_extras.append({'name': 'CONNECTIONS_PER_SECOND', 'value': resources.connections_per_second | string}) %}
+{% endif %}
+{% set merged_env = inline_env | merge_environment(env_extras) %}
+{% set inline_env_items = merged_env.items %}
+{% set health_cmd = health_defaults.command %}
+{% set health_interval_seconds = health_defaults.interval_seconds %}
+{% set health_timeout_seconds = health_defaults.timeout_seconds %}
+{% set health_retries = health_defaults.retries %}
 {% set replicas = service_replicas | default(1) %}
 {% set ports = service_ports | default([]) %}
 {% set container_port = ports[0].target if ports | length > 0 else 8080 %}
 {% set service_port_value = ports[0].published if ports | length > 0 and ports[0].published is defined else container_port %}
-{% set resources = service_resources | default({'memory_mb': 256, 'cpu_cores': 1}) %}
 {% set memory_request = resources.memory_mb | default(256) %}
 {% set cpu_cores = resources.cpu_cores | default(1) %}
-{% set connections_per_second = resources.connections_per_second if resources.connections_per_second is defined else None %}
 {% set volume_config = service_volumes[0] if service_volumes is defined and service_volumes | length > 0 else None %}
 {% set use_host_path = volume_config is mapping and volume_config.host_path is defined %}
 {% set host_path = volume_config.host_path if use_host_path else None %}
@@ -118,9 +122,9 @@ spec:
     metadata:
       labels:
         app: {{ svc_name }}
-{% if secrets is defined and secrets.rotation_timestamp is defined and secrets.rotation_timestamp is not none %}
+{% if secrets_info.rotation_timestamp is not none %}
       annotations:
-        shma.dev/secrets-rotation: "{{ secrets.rotation_timestamp }}"
+        shma.dev/secrets-rotation: "{{ secrets_info.rotation_timestamp }}"
 {% endif %}
     spec:
       securityContext:
@@ -141,15 +145,8 @@ spec:
                 - {{ cap }}
 {% endfor %}
 {% endif %}
-{% if secrets is defined and secrets.rotation_timestamp is defined and secrets.rotation_timestamp is not none %}
-  {% set _ = inline_env_ns.items.append({'name': 'SHMA_SECRETS_ROTATION', 'value': secrets.rotation_timestamp | string}) %}
-{% endif %}
-{% if connections_per_second is not none %}
-  {% set _ = inline_env_ns.items.append({'name': 'CONNECTIONS_PER_SECOND', 'value': connections_per_second | string}) %}
-{% endif %}
-{% set inline_env = inline_env_ns.items %}
 {% set has_secret_env = secret_env | length > 0 %}
-{% set has_inline_env = inline_env | length > 0 %}
+{% set has_inline_env = inline_env_items | length > 0 %}
 {% if has_secret_env or has_inline_env %}
           env:
 {% if has_secret_env %}
@@ -162,7 +159,7 @@ spec:
 {% endfor %}
 {% endif %}
 {% if has_inline_env %}
-{% for item in inline_env %}
+{% for item in inline_env_items %}
             - name: {{ item.name }}
               value: {{ item.value | to_json }}
 {% endfor %}

--- a/templates/podman.yml.j2
+++ b/templates/podman.yml.j2
@@ -1,21 +1,14 @@
 {% set mounts_config = mounts | default({}) %}
 {% set ephemeral_mounts = mounts_config.ephemeral_mounts | default([]) %}
-{% set default_apply_targets = ['docker', 'podman', 'kubernetes', 'proxmox', 'baremetal'] %}
-{% set security = service_security | default({}) %}
-{% set default_run_user = security.run_as_user if security.run_as_user is defined else 65532 %}
-{% set default_run_group = security.run_as_group if security.run_as_group is defined else default_run_user %}
-{% set quadlet_user = security.user if security.user is defined else ((default_run_user | string) ~ ':' ~ (default_run_group | string)) %}
-{% set read_only_root = security.read_only_root_filesystem if security.read_only_root_filesystem is defined else true %}
-{% set drop_caps_default = security.capabilities_drop | default(['ALL']) %}
-{% if drop_caps_default is string %}{% set drop_caps_default = [drop_caps_default] %}{% endif %}
-{% set no_new_privs = security.no_new_privileges if security.no_new_privileges is defined else true %}
-{% set bounding_set = security.capability_bounding_set if security.capability_bounding_set is defined else [] %}
-{% if bounding_set is string %}{% set bounding_set = [bounding_set] %}{% endif %}
+{% set security_defaults = (service_security if service_security is defined else None) | normalize_security %}
+{% set quadlet_user = security_defaults.compose_user %}
+{% set read_only_root = security_defaults.read_only_root_filesystem %}
+{% set drop_caps_default = security_defaults.capabilities_drop %}
+{% set no_new_privs = security_defaults.no_new_privileges %}
+{% set bounding_set = security_defaults.capability_bounding_set %}
 {% set tmpfs_hardening_flags = ['nosuid', 'nodev', 'noexec'] %}
 {% set podman_tmpfs = namespace(items=[]) %}
-{% for mount in ephemeral_mounts %}
-  {% set apply_targets = mount.apply_to | default(default_apply_targets) %}
-  {% if 'podman' in apply_targets %}
+{% for mount in ephemeral_mounts | select_mounts('podman') %}
     {% set options = [] %}
     {% for flag in tmpfs_hardening_flags %}
       {% if flag not in options %}{% set _ = options.append(flag) %}{% endif %}
@@ -27,8 +20,10 @@
     {% if entry not in podman_tmpfs.items %}{% set _ = podman_tmpfs.items.append(entry) %}{% endif %}
   {% endif %}
 {% endfor %}
-{% set secret_env = secrets.env if secrets is defined and secrets.env is not none and secrets.env | length > 0 else [] %}
-{% set file_secrets = secrets.files if secrets is defined and secrets.files is not none and secrets.files | length > 0 else [] %}
+{% set secrets_info = (secrets if secrets is defined else None) | normalize_secrets(service_name | default(service_id)) %}
+{% set secret_env = secrets_info.env %}
+{% set file_secrets = secrets_info.files %}
+{% set secrets_rotation = secrets_info.rotation_timestamp %}
 {% set quadlet_scope_value = quadlet_scope | default('system') %}
 {% if quadlet_scope_value == 'user' %}
 {% set quadlet_base_dir = '%h/.config/containers/systemd' %}
@@ -40,11 +35,16 @@
 {% set ports = service_ports | default([]) %}
 {% set volumes = service_volumes | default([]) %}
 {% set inline_env = service_env | default([]) %}
-{% set inline_env_names = inline_env | map(attribute='name') | list %}
 {% set resources = service_resources | default({}) %}
+{% set env_extras = [] %}
 {% if resources.connections_per_second is defined %}
-  {% set inline_env = inline_env + [{'name': 'CONNECTIONS_PER_SECOND', 'value': resources.connections_per_second | string}] %}
+  {% set _ = env_extras.append({'name': 'CONNECTIONS_PER_SECOND', 'value': resources.connections_per_second | string}) %}
 {% endif %}
+{% if secrets_rotation is not none %}
+  {% set _ = env_extras.append({'name': 'SHMA_SECRETS_ROTATION', 'value': secrets_rotation}) %}
+{% endif %}
+{% set inline_env_data = inline_env | merge_environment(env_extras) %}
+{% set inline_env_items = inline_env_data.items %}
 {% set auto_update_mode = quadlet_auto_update | default('none') %}
 [Unit]
 Description={{ service_unit_description | default('Managed container for ' ~ (service_name | default(service_id))) }}
@@ -61,12 +61,9 @@ NoNewPrivileges={{ 'true' if no_new_privs else 'false' }}
 {% for cap in drop_caps_default %}
 DropCapability={{ cap }}
 {% endfor %}
-{% for env in inline_env %}
+{% for env in inline_env_items %}
 Environment={{ env.name }}={{ env.value }}
 {% endfor %}
-{% if secrets is defined and secrets.rotation_timestamp is defined and secrets.rotation_timestamp is not none and 'SHMA_SECRETS_ROTATION' not in inline_env_names %}
-Environment=SHMA_SECRETS_ROTATION={{ secrets.rotation_timestamp }}
-{% endif %}
 {% if secret_env %}
 EnvironmentFile={{ env_file_path }}
 {% endif %}
@@ -86,10 +83,11 @@ Tmpfs={{ entry }}
 {% for port in ports %}
 PublishPort={{ port.host_ip | default('') }}{% if port.host_ip is defined and port.host_ip | string | length > 0 %}:{% endif %}{{ port.published | default(port.target) }}:{{ port.target }}{% if port.protocol is defined %}/{{ port.protocol }}{% endif %}
 {% endfor %}
-HealthCmd={{ (health.cmd | default(['true'])) | join(' ') }}
-HealthInterval={{ health.interval | default('10s') }}
-HealthTimeout={{ health.timeout | default('5s') }}
-HealthRetries={{ health.retries | default(3) }}
+{% set health_defaults = (health if health is defined else None) | normalize_health %}
+HealthCmd={{ health_defaults.command | join(' ') }}
+HealthInterval={{ health_defaults.interval }}
+HealthTimeout={{ health_defaults.timeout }}
+HealthRetries={{ health_defaults.retries }}
 
 [Service]
 Restart=always

--- a/templates/proxmox.yml.j2
+++ b/templates/proxmox.yml.j2
@@ -6,16 +6,12 @@
 {% set cmd_list = service_commands | default([]) %}
 {% set mounts_config = mounts | default({}) %}
 {% set ephemeral_mounts = mounts_config.ephemeral_mounts | default([]) %}
-{% set default_apply_targets = ['docker', 'podman', 'kubernetes', 'proxmox', 'baremetal'] %}
 {% set proxmox_tmpfs = namespace(items=[]) %}
-{% for mount in ephemeral_mounts %}
-  {% set apply_targets = mount.apply_to | default(default_apply_targets) %}
-  {% if 'proxmox' in apply_targets %}
-    {% set options = [] %}
-    {% if mount.mode is defined %}{% set _ = options.append('mode=' ~ mount.mode) %}{% endif %}
-    {% if mount.size is defined %}{% set _ = options.append('size=' ~ mount.size) %}{% endif %}
-    {% set _ = proxmox_tmpfs.items.append({'path': mount.path, 'options': options}) %}
-  {% endif %}
+{% for mount in ephemeral_mounts | select_mounts('proxmox') %}
+  {% set options = [] %}
+  {% if mount.mode is defined %}{% set _ = options.append('mode=' ~ mount.mode) %}{% endif %}
+  {% if mount.size is defined %}{% set _ = options.append('size=' ~ mount.size) %}{% endif %}
+  {% set _ = proxmox_tmpfs.items.append({'path': mount.path, 'options': options}) %}
 {% endfor %}
 {% set pkg_names = namespace(items=[]) %}
 {% for pkg in pkg_list %}


### PR DESCRIPTION
## Summary
- add runtime helper filters for security defaults, secrets, mount selection, and environment merging
- update Docker, Podman, Kubernetes, baremetal, and Proxmox templates to reuse the shared helpers and normalized health checks

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'ci')*

------
https://chatgpt.com/codex/tasks/task_e_68f505a4858c832eb8f7f22163aaf366