### PR TITLE
Add network policy support and harden Kubernetes manifest generation

### DIFF
--- a/docs/kubernetes.md
+++ b/docs/kubernetes.md
@@ -36,9 +36,10 @@ ansible-galaxy collection install kubernetes.core
 - `Secret` – named `<service_id>-env`, containing keys for every `secrets.env` entry.
 - `Secret` – named `<service_id>-files`, storing the rendered secret files.
 - `PersistentVolumeClaim` – sized from `service_storage_gb` or `service_storage_size`. Skipped automatically when `service_volumes.host_path` is provided.
-- `emptyDir` – emitted for each `mounts.ephemeral_mounts` entry that applies to Kubernetes, defaulting to `medium: Memory`.
+- `emptyDir` – emitted for each writable `mounts.ephemeral_mounts` entry that applies to Kubernetes, defaulting to `medium: Memory`. Entries flagged with `read_only: true` are ignored so pods don't get unintended scratch space.
 - `Deployment` – references the Secret for env vars, mounts secret files, configures probes/resources, and enforces non-root security defaults.
-- `Service` – exposes declared `service_ports` within the cluster.
+- `Service` – exposes declared `service_ports` within the cluster. When no ports are provided the Service resource is omitted entirely.
+- `NetworkPolicy` – isolates the pods using an allow-all egress rule and a same-namespace ingress rule for the declared service port. Override or disable by setting `service_security.network_policy`.
 
 Snippet:
 

--- a/schemas/service.schema.yml
+++ b/schemas/service.schema.yml
@@ -338,6 +338,19 @@ properties:
         type: boolean
       allow_privilege_escalation:
         type: boolean
+      network_policy:
+        type: object
+        properties:
+          enabled:
+            type: boolean
+          policy_types:
+            type: array
+            items:
+              type: string
+          ingress:
+            type: array
+          egress:
+            type: array
       capability_bounding_set:
         type: array
         items:

--- a/templates/kubernetes.yml.j2
+++ b/templates/kubernetes.yml.j2
@@ -1,4 +1,19 @@
 #jinja2: lstrip_blocks: True, trim_blocks: True
+{% macro render_secret(secret_name, namespace, entries) -%}
+{% if entries %}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ secret_name }}
+  namespace: {{ namespace }}
+type: Opaque
+stringData:
+{% for key, value in entries.items() %}
+  {{ key }}: {{ value | to_json }}
+{% endfor %}
+{% endif %}
+{%- endmacro %}
 {% set svc_name = service_name | default(service_id) %}
 {% set svc_namespace = service_namespace | default('default') %}
 {% set mounts_config = mounts | default({}) %}
@@ -12,10 +27,28 @@
 {% if drop_caps_default is string %}{% set drop_caps_default = [drop_caps_default] %}{% endif %}
 {% set no_new_privs = security.no_new_privileges if security.no_new_privileges is defined else true %}
 {% set allow_priv_escalation = security.allow_privilege_escalation if security.allow_privilege_escalation is defined else (not no_new_privs) %}
-{% set ingress_spec = ingress | default({}) %}
-{% set ingress_routes = ingress_spec.routes | default([]) %}
-{% set ingress_flag = ingress_spec.get('enabled') if ingress_spec is mapping else none %}
-{% set ingress_enabled = (ingress_flag if ingress_flag is not none else (ingress_routes | length > 0)) %}
+{% set ports = service_ports | default([]) %}
+{% set container_port = ports[0].target if ports | length > 0 else none %}
+{% set service_port_value = ports[0].published if ports | length > 0 and ports[0].published is defined else container_port %}
+{% set ingress_raw = ingress | default({}) %}
+{% if ingress_raw is mapping %}
+  {% set ingress_flag = ingress_raw.get('enabled') %}
+  {% set ingress_source_routes = ingress_raw.get('routes', []) %}
+{% else %}
+  {% set ingress_flag = none %}
+  {% set ingress_source_routes = [] %}
+{% endif %}
+{% set ingress_ns = namespace(items=[]) %}
+{% for route in ingress_source_routes if route is mapping %}
+  {% set host = route.host if route.host is defined else none %}
+  {% set path_prefix = route.path_prefix if route.path_prefix is defined else '/' %}
+  {% if host %}
+    {% set sanitized_route = route | combine({'path_prefix': path_prefix}) %}
+    {% set _ = ingress_ns.items.append(sanitized_route) %}
+  {% endif %}
+{% endfor %}
+{% set ingress_routes = ingress_ns.items %}
+{% set ingress_enabled = ((ingress_flag if ingress_flag is not none else (ingress_routes | length > 0)) and container_port is not none) %}
 {% set k8s_ephemeral = namespace(items=[]) %}
 {% for mount in ephemeral_mounts %}
   {% set apply_targets = mount.apply_to | default(default_apply_targets) %}
@@ -28,7 +61,9 @@
       'size': mount.size if mount.size is defined else None,
       'read_only': mount.read_only if mount.read_only is defined else false
     } %}
-    {% set _ = k8s_ephemeral.items.append(entry) %}
+    {% if not entry.read_only %}
+      {% set _ = k8s_ephemeral.items.append(entry) %}
+    {% endif %}
   {% endif %}
 {% endfor %}
 {% set secret_env = secrets.env if secrets is defined and secrets.env is not none and secrets.env | length > 0 else [] %}
@@ -42,9 +77,6 @@
 {% set health_timeout_seconds = (health.timeout | default('5s')) | regex_replace('s$', '') | int %}
 {% set health_retries = health.retries | default(3) %}
 {% set replicas = service_replicas | default(1) %}
-{% set ports = service_ports | default([]) %}
-{% set container_port = ports[0].target if ports | length > 0 else 8080 %}
-{% set service_port_value = ports[0].published if ports | length > 0 and ports[0].published is defined else container_port %}
 {% set resources = service_resources | default({'memory_mb': 256, 'cpu_cores': 1}) %}
 {% set memory_request = resources.memory_mb | default(256) %}
 {% set cpu_cores = resources.cpu_cores | default(1) %}
@@ -63,32 +95,17 @@
 {% set storage_size = '1Gi' %}
 {% endif %}
 {% set volume_mount_path = volume_config.target if volume_config is mapping and volume_config.target is defined else '/data' %}
-{%- if secret_env -%}
----
-apiVersion: v1
-kind: Secret
-metadata:
-  name: {{ env_secret_name }}
-  namespace: {{ svc_namespace }}
-type: Opaque
-stringData:
+{% set env_secret_entries = namespace(items={}) %}
 {% for item in secret_env %}
-  {{ item.name }}: {{ item.value | to_json }}
+  {% set env_secret_entries.items = env_secret_entries.items | combine({item.name: item.value}) %}
 {% endfor %}
-{% endif -%}
-{%- if file_secrets -%}
----
-apiVersion: v1
-kind: Secret
-metadata:
-  name: {{ file_secret_name }}
-  namespace: {{ svc_namespace }}
-type: Opaque
-stringData:
+{% set file_secret_entries = namespace(items={}) %}
 {% for secret in file_secrets %}
-  {{ secret.name }}: {{ (secret.value | default(secret.content) | default('', true)) | to_json }}
+  {% set secret_value = secret.value | default(secret.content) | default('', true) %}
+  {% set file_secret_entries.items = file_secret_entries.items | combine({secret.name: secret_value}) %}
 {% endfor %}
-{% endif -%}
+{{ render_secret(env_secret_name, svc_namespace, env_secret_entries.items) }}
+{{ render_secret(file_secret_name, svc_namespace, file_secret_entries.items) }}
 {%- if not use_host_path -%}
 ---
 apiVersion: v1
@@ -168,8 +185,10 @@ spec:
 {% endfor %}
 {% endif %}
 {% endif %}
+{% if container_port is not none %}
           ports:
             - containerPort: {{ container_port }}
+{% endif %}
           volumeMounts:
             - name: data
               mountPath: {{ volume_mount_path }}
@@ -242,6 +261,7 @@ spec:
                 path: {{ secret.name }}
 {% endfor %}
 {% endif %}
+{% if container_port is not none %}
 ---
 apiVersion: v1
 kind: Service
@@ -295,5 +315,63 @@ spec:
         - {{ host }}
 {% endfor %}
 {% endfor %}
+{% endif %}
+{% endif %}
+{% endif %}
+{% set network_policy_spec = security.network_policy if security.network_policy is defined and security.network_policy is mapping else {} %}
+{% set network_policy_enabled_flag = network_policy_spec.get('enabled') if network_policy_spec else none %}
+{% set policy_types_candidate = network_policy_spec.policy_types if network_policy_spec.policy_types is defined and network_policy_spec.policy_types is iterable and network_policy_spec.policy_types is not string else [] %}
+{% set policy_types = policy_types_candidate | list if policy_types_candidate else [] %}
+{% if not policy_types %}
+  {% if container_port is not none %}
+    {% set policy_types = ['Ingress', 'Egress'] %}
+  {% else %}
+    {% set policy_types = ['Egress'] %}
+  {% endif %}
+{% endif %}
+{% set policy_types = policy_types | unique %}
+{% set ingress_candidate = network_policy_spec.ingress if network_policy_spec.ingress is defined and network_policy_spec.ingress is iterable and network_policy_spec.ingress is not string else [] %}
+{% set egress_candidate = network_policy_spec.egress if network_policy_spec.egress is defined and network_policy_spec.egress is iterable and network_policy_spec.egress is not string else [] %}
+{% if 'Ingress' in policy_types %}
+  {% set ingress_rules = ingress_candidate | list %}
+  {% if not ingress_rules and container_port is not none %}
+    {% set default_from = [{'namespaceSelector': {'matchLabels': {'kubernetes.io/metadata.name': svc_namespace}}}] %}
+    {% set default_ports = [{'port': service_port_value, 'protocol': 'TCP'}] %}
+    {% set ingress_rules = [{'from': default_from, 'ports': default_ports}] %}
+  {% endif %}
+{% else %}
+  {% set ingress_rules = [] %}
+{% endif %}
+{% if 'Egress' in policy_types %}
+  {% set egress_rules = egress_candidate | list %}
+  {% if not egress_rules %}
+    {% set egress_rules = [{}] %}
+  {% endif %}
+{% else %}
+  {% set egress_rules = [] %}
+{% endif %}
+{% set network_policy_enabled = (network_policy_enabled_flag if network_policy_enabled_flag is not none else (container_port is not none)) and policy_types %}
+{% if network_policy_enabled %}
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ svc_name }}
+  namespace: {{ svc_namespace }}
+spec:
+  podSelector:
+    matchLabels:
+      app: {{ svc_name }}
+  policyTypes:
+{% for policy_type in policy_types %}
+    - {{ policy_type }}
+{% endfor %}
+{% if ingress_rules %}
+  ingress:
+{{ ingress_rules | to_nice_yaml(indent=2) | indent(4, True) | regex_replace('(-)\\s+', '\\1 ') }}
+{% endif %}
+{% if egress_rules %}
+  egress:
+{{ egress_rules | to_nice_yaml(indent=2) | indent(4, True) | regex_replace('(-)\\s+', '\\1 ') }}
 {% endif %}
 {% endif %}

--- a/tests/sample_service_portless.yml
+++ b/tests/sample_service_portless.yml
@@ -1,0 +1,29 @@
+service_id: portless-service
+service_name: portless-service
+service_image: docker.io/library/busybox@sha256:1d6cb4dd3bfa4f7c517d68d548406d82b88144fef0a2b7ad9c7e2e5e6a1b2c3d
+service_env: []
+service_volumes: []
+service_ip: 192.0.2.80
+service_namespace: sandbox
+service_replicas: 1
+service_storage_gb: 1
+service_resources:
+  memory_mb: 128
+  cpu_cores: 0.5
+runtime_templates:
+  kubernetes: ../templates/kubernetes.yml.j2
+mounts:
+  persistent_volumes:
+    - name: data
+      path: /var/lib/portless
+  ephemeral_mounts:
+    - name: cache-readonly
+      path: /var/run/cache
+      apply_to: [kubernetes]
+      read_only: true
+health:
+  cmd:
+    - /bin/sh
+    - -c
+    - "exit 0"
+needs_container_runtime: false

--- a/tests/verify_kubernetes_manifest.yml
+++ b/tests/verify_kubernetes_manifest.yml
@@ -38,6 +38,8 @@
         env_secret_resources: "{{ kubernetes_resources | selectattr('kind', '==', 'Secret') | selectattr('metadata.name', '==', deployment_name ~ '-env') | list }}"
         file_secret_resources: "{{ kubernetes_resources | selectattr('kind', '==', 'Secret') | selectattr('metadata.name', '==', deployment_name ~ '-files') | list }}"
         pvc_resources: "{{ kubernetes_resources | selectattr('kind', '==', 'PersistentVolumeClaim') | list }}"
+        service_resource_docs: "{{ kubernetes_resources | selectattr('kind', '==', 'Service') | selectattr('metadata.name', '==', deployment_name) | list }}"
+        network_policy_resources: "{{ kubernetes_resources | selectattr('kind', '==', 'NetworkPolicy') | selectattr('metadata.name', '==', deployment_name) | list }}"
 
     - name: Validate environment secret layout
       ansible.builtin.assert:
@@ -68,6 +70,28 @@
         that:
           - deployment_resources | length == 1
         fail_msg: "Expected a single Deployment resource in the manifest."
+
+    - name: Validate service exposure
+      ansible.builtin.assert:
+        that:
+          - service_resource_docs | length == 1
+          - (service_resource_docs | length == 1) and (service_resource_docs[0].spec.ports | length == 1)
+          - (service_resource_docs | length == 1) and (service_resource_docs[0].spec.ports[0].targetPort == service_ports[0].target)
+          - (service_resource_docs | length == 1) and (service_resource_docs[0].spec.ports[0].port == (service_ports[0].published | default(service_ports[0].target)))
+        fail_msg: "Service resource must expose the declared port mapping."
+
+    - name: Validate network policy defaults
+      ansible.builtin.assert:
+        that:
+          - network_policy_resources | length == 1
+          - (network_policy_resources | length == 1) and (network_policy_resources[0].spec.policyTypes | select('equalto', 'Ingress') | list | length == 1)
+          - (network_policy_resources | length == 1) and (network_policy_resources[0].spec.policyTypes | select('equalto', 'Egress') | list | length == 1)
+          - (network_policy_resources | length == 1) and (network_policy_resources[0].spec.ingress | length == 1)
+          - (network_policy_resources | length == 1) and (network_policy_resources[0].spec.ingress[0].ports[0].port == (service_ports[0].published | default(service_ports[0].target)))
+          - (network_policy_resources | length == 1) and (network_policy_resources[0].spec.ingress[0].from[0].namespaceSelector.matchLabels['kubernetes.io/metadata.name'] == service_namespace)
+          - (network_policy_resources | length == 1) and (network_policy_resources[0].spec.egress | length == 1)
+          - (network_policy_resources | length == 1) and (network_policy_resources[0].spec.egress[0] == {})
+        fail_msg: "NetworkPolicy must default to namespace-scoped ingress and unrestricted egress."
 
     - name: Extract deployment details
       ansible.builtin.set_fact:

--- a/tests/verify_kubernetes_portless.yml
+++ b/tests/verify_kubernetes_portless.yml
@@ -1,0 +1,69 @@
+---
+- name: Validate portless Kubernetes manifest omits Services
+  hosts: localhost
+  gather_facts: false
+  connection: local
+  vars:
+    runtime: kubernetes
+  tasks:
+    - name: Load portless service definition
+      ansible.builtin.include_vars:
+        file: "{{ playbook_dir }}/sample_service_portless.yml"
+
+    - name: Render Kubernetes runtime
+      ansible.builtin.include_role:
+        name: roles/common/render_runtime
+
+    - name: Read rendered manifest
+      ansible.builtin.slurp:
+        src: "{{ runtime_config_path }}"
+      register: rendered_manifest
+
+    - name: Parse manifest documents
+      ansible.builtin.set_fact:
+        manifest_documents: "{{ rendered_manifest.content | b64decode | from_yaml_all | list }}"
+
+    - name: Filter Kubernetes resources
+      ansible.builtin.set_fact:
+        kubernetes_resources: "{{ manifest_documents | reject('equalto', None) | list }}"
+
+    - name: Determine resource name
+      ansible.builtin.set_fact:
+        deployment_name: "{{ service_name | default(service_id) }}"
+
+    - name: Collect Kubernetes resources by kind
+      ansible.builtin.set_fact:
+        deployment_resources: "{{ kubernetes_resources | selectattr('kind', '==', 'Deployment') | selectattr('metadata.name', '==', deployment_name) | list }}"
+        service_resource_docs: "{{ kubernetes_resources | selectattr('kind', '==', 'Service') | list }}"
+        network_policy_resources: "{{ kubernetes_resources | selectattr('kind', '==', 'NetworkPolicy') | list }}"
+
+    - name: Ensure deployment rendered
+      ansible.builtin.assert:
+        that:
+          - deployment_resources | length == 1
+        fail_msg: "Expected a Deployment resource for the portless service."
+
+    - name: Extract pod details
+      ansible.builtin.set_fact:
+        primary_container: "{{ deployment_resources[0].spec.template.spec.containers[0] }}"
+        pod_volumes: "{{ deployment_resources[0].spec.template.spec.volumes | default([]) }}"
+
+    - name: Validate absence of Service and NetworkPolicy
+      ansible.builtin.assert:
+        that:
+          - service_resource_docs | length == 0
+          - network_policy_resources | length == 0
+        fail_msg: "Portless services must not render Service or NetworkPolicy resources."
+
+    - name: Confirm container omits ports
+      ansible.builtin.assert:
+        that:
+          - primary_container.ports is undefined
+        fail_msg: "Containers without declared ports must not receive a default containerPort."
+
+    - name: Confirm read-only ephemeral mount skipped
+      ansible.builtin.assert:
+        that:
+          - pod_volumes | selectattr('name', '==', 'cache-readonly') | list | length == 0
+          - primary_container.volumeMounts | default([]) | selectattr('name', '==', 'cache-readonly') | list | length == 0
+        fail_msg: "Read-only ephemeral mounts must not create emptyDir volumes."


### PR DESCRIPTION
## Summary
- sanitize ingress route handling and avoid defaulting to ports or emptyDir mounts when unnecessary
- add reusable secret rendering macro and emit network policies with configurable overrides
- document the new behaviour and extend tests with service/network-policy assertions and a portless sample

## Testing
- ansible-playbook tests/verify_kubernetes_manifest.yml -e runtime=kubernetes -e @tests/sample_service.yml
- ansible-playbook tests/verify_kubernetes_portless.yml -e runtime=kubernetes -e @tests/sample_service_portless.yml

------
https://chatgpt.com/codex/tasks/task_e_68f50578c414832e929f0518da675d0b