### PR TITLE
Refactor secrets handling and update runtime templates

### DIFF
--- a/ci/validate_systemd_unit.py
+++ b/ci/validate_systemd_unit.py
@@ -68,11 +68,13 @@ def ephemeral_paths_for_baremetal(service: dict) -> List[str]:
         path = mount.get("path")
         if not path:
             continue
-        apply_to: Iterable[str] | None = mount.get("apply_to")
-        if not apply_to:
-            apply_to = DEFAULT_APPLY_TARGETS
-        if "baremetal" in apply_to:
-            paths.append(path)
+        runtimes: Iterable[str] | None = mount.get("runtimes")
+        if runtimes is None:
+            runtimes = mount.get("apply_to")
+        if runtimes:
+            if "baremetal" not in runtimes:
+                continue
+        paths.append(path)
     return paths
 
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,8 +2,6 @@
 
 A runtime-agnostic infrastructure-as-code framework for deploying self-hosted applications across **Proxmox LXC**, **Docker Compose**, **Podman Quadlets**, **Kubernetes**, and **bare-metal systemd** from a single service contract.
 
-> **Heads-up:** Earlier drafts referenced an "Advanced Research mode". That experiment has been retired—everything documented here reflects the only supported workflow.
-
 ## Key Features
 
 - **Write Once, Deploy Anywhere** – render the same service definition into runtime-specific manifests and unit files.
@@ -81,7 +79,6 @@ mounts:
   ephemeral_mounts:
     - name: runtime-run
       path: /run/sample-service
-      apply_to: [docker, podman, kubernetes, proxmox, baremetal]
       medium: Memory
 
 exports:
@@ -92,13 +89,14 @@ exports:
 
 secrets:
   shred_after_apply: true
-  env:
+  items:
     - name: SAMPLE_SERVICE_TOKEN
+      type: env
       value: "{{ sample_service_token }}"
-  files:
     - name: tls-cert
+      type: file
       target: /etc/sample-service/certs/tls.crt
-      value: "{{ sample_service_tls_cert }}"
+      content: "{{ sample_service_tls_cert }}"
 ```
 
 > **Note:** Always declare host mounts with `service_volumes` (plural). The legacy `service_volume` key has been removed from the framework; migrate older inventories to the plural form before running validation to avoid schema failures.

--- a/docs/edge.md
+++ b/docs/edge.md
@@ -87,7 +87,7 @@ the edge configuration is correct.
 
 ## Roles
 
-> **Note:** There is no standalone `edge_proxy_nginx` role. Nginx automation is provided through the OPNsense plugin via `edge_opnsense_nginx`.
+> **Note:** Nginx automation is delivered by the OPNsense-specific `edge_opnsense_nginx` role; there is no standalone `edge_proxy_nginx` role in this repository.
 
 ### `edge_ingress`
 

--- a/filter_plugins/runtime_common.py
+++ b/filter_plugins/runtime_common.py
@@ -1,0 +1,336 @@
+"""Shared filter helpers for runtime template rendering."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Iterable, List, Mapping, Optional, Sequence
+
+from ansible.errors import AnsibleFilterError
+
+from .health import get_health_command
+
+
+def _as_list(value: Any) -> List[Any]:
+    if value is None:
+        return []
+    if isinstance(value, (list, tuple, set)):
+        return list(value)
+    return [value]
+
+
+def _unique(items: Iterable[Any]) -> List[Any]:
+    seen = set()
+    result: List[Any] = []
+    for item in items:
+        if item not in seen:
+            seen.add(item)
+            result.append(item)
+    return result
+
+
+def ensure_env_entries(value: Any, *, context: str) -> List[Dict[str, Any]]:
+    entries: List[Dict[str, Any]] = []
+    if value is None:
+        return entries
+    if isinstance(value, Mapping):
+        for name, val in value.items():
+            entries.append({"name": name, "value": val})
+        return entries
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes)):
+        for item in value:
+            if not isinstance(item, Mapping):
+                raise AnsibleFilterError(
+                    f"{context} entries must be dictionaries with 'name' and 'value' keys"
+                )
+            if "name" not in item:
+                raise AnsibleFilterError(
+                    f"{context} entry {item!r} is missing the required 'name' key"
+                )
+            entries.append(
+                {
+                    "name": item["name"],
+                    "value": item.get("value"),
+                }
+            )
+        return entries
+    raise AnsibleFilterError(
+        f"{context} must be a sequence or mapping, received {type(value).__name__}"
+    )
+
+
+def normalize_security(security: Any | None) -> Dict[str, Any]:
+    src: Mapping[str, Any] = security or {}
+    drop_caps = src.get("capabilities_drop", ["ALL"])
+    drop_caps_list = _as_list(drop_caps)
+    bounding_set = _as_list(src.get("capability_bounding_set", []))
+    allowed_apparmor = _as_list(
+        src.get("allowed_apparmor_profiles", ["docker-default", "unconfined"])
+    )
+
+    run_user = src.get("run_as_user", 65532)
+    run_group = src.get("run_as_group", run_user)
+
+    defaults = {
+        "run_user": run_user,
+        "run_group": run_group,
+        "read_only_root": src.get("read_only_root_filesystem", True),
+        "capabilities_drop": drop_caps_list,
+        "no_new_privileges": src.get("no_new_privileges", True),
+        "allow_privilege_escalation": src.get(
+            "allow_privilege_escalation",
+            not src.get("no_new_privileges", True),
+        ),
+        "apparmor_profile": src.get("apparmor_profile", "docker-default"),
+        "allowed_apparmor_profiles": allowed_apparmor,
+        "compose_user": src.get("user"),
+        "capability_bounding_set": bounding_set,
+        "user_namespace": src.get("user_namespace"),
+        "init": src.get("init"),
+    }
+    return defaults
+
+
+def _normalise_secret_item(item: Mapping[str, Any]) -> Dict[str, Any]:
+    secret_type = item.get("type") or item.get("kind")
+    if secret_type is None:
+        if "target" in item or "mode" in item or "content" in item:
+            secret_type = "file"
+        else:
+            secret_type = "env"
+
+    secret_type = str(secret_type).lower()
+    if secret_type not in {"env", "file"}:
+        raise AnsibleFilterError(f"Unsupported secret type {secret_type!r}")
+
+    name = item.get("name")
+    if not name:
+        raise AnsibleFilterError("Secret entries must define a non-empty name")
+
+    base: Dict[str, Any] = {
+        "name": str(name),
+        "type": secret_type,
+    }
+
+    if secret_type == "env":
+        base["value"] = item.get("value")
+    else:
+        base["target"] = item.get("target")
+        base["mode"] = item.get("mode")
+        base["content"] = item.get("content", item.get("value"))
+    return base
+
+
+def normalize_secrets(secrets: Any | None) -> Dict[str, Any]:
+    if secrets is None:
+        secrets = {}
+
+    if isinstance(secrets, Mapping):
+        source = secrets
+    else:
+        # Support attribute access objects by copying attrs into a dict.
+        source = {k: getattr(secrets, k) for k in dir(secrets) if not k.startswith("_")}
+
+    items: List[Dict[str, Any]] = []
+
+    def add_env(entry: Mapping[str, Any]) -> None:
+        normalized = _normalise_secret_item({"type": "env", **entry})
+        if normalized["name"] not in env_names:
+            env_items.append(normalized)
+            env_names.add(normalized["name"])
+            items.append(normalized)
+
+    def add_file(entry: Mapping[str, Any]) -> None:
+        normalized = _normalise_secret_item({"type": "file", **entry})
+        if normalized["name"] not in file_names:
+            file_items.append(normalized)
+            file_names.add(normalized["name"])
+            items.append(normalized)
+
+    env_items: List[Dict[str, Any]] = []
+    env_names: set[str] = set()
+    file_items: List[Dict[str, Any]] = []
+    file_names: set[str] = set()
+
+    for entry in source.get("items", []) or []:
+        normalized = _normalise_secret_item(entry)
+        if normalized["type"] == "env":
+            add_env(normalized)
+        else:
+            add_file(normalized)
+
+    for entry in source.get("env", []) or []:
+        add_env(entry)
+
+    for entry in source.get("files", []) or []:
+        add_file(entry)
+
+    rotation = source.get("rotation_timestamp")
+    shred = source.get("shred_after_apply", True)
+
+    return {
+        "items": items,
+        "env": env_items,
+        "files": file_items,
+        "catalog": {
+            "env_names": sorted(env_names),
+            "file_names": sorted(file_names),
+        },
+        "rotation_timestamp": rotation,
+        "shred_after_apply": bool(shred),
+    }
+
+
+def secrets_env_map(secret_context: Mapping[str, Any]) -> Dict[str, Any]:
+    env_items = secret_context.get("env", []) if secret_context else []
+    mapping: Dict[str, Any] = {}
+    for item in env_items:
+        name = item.get("name")
+        if name and name not in mapping:
+            mapping[name] = item.get("value")
+    return mapping
+
+
+def normalize_mounts(mounts: Any | None) -> Dict[str, Any]:
+    src: Mapping[str, Any] = mounts or {}
+    ephemeral_raw = src.get("ephemeral_mounts") or []
+    normalized: List[Dict[str, Any]] = []
+
+    for entry in ephemeral_raw:
+        if not isinstance(entry, Mapping):
+            raise AnsibleFilterError("ephemeral_mounts entries must be mappings")
+        name = entry.get("name") or f"ephemeral-{len(normalized) + 1}"
+        path = entry.get("path")
+        if not path:
+            raise AnsibleFilterError(f"ephemeral mount {name!r} must define a path")
+        runtimes = entry.get("runtimes") or entry.get("apply_to") or []
+        normalized.append(
+            {
+                "name": str(name),
+                "path": str(path),
+                "medium": entry.get("medium"),
+                "size": entry.get("size"),
+                "mode": entry.get("mode"),
+                "read_only": bool(entry.get("read_only", False)),
+                "runtimes": list(runtimes) if runtimes else [],
+            }
+        )
+
+    return {"ephemeral": normalized}
+
+
+def select_ephemeral_mounts(
+    mounts: Any, runtime: str | None = None
+) -> List[Dict[str, Any]]:
+    candidates = mounts or []
+    if runtime is None:
+        return list(candidates)
+
+    selected: List[Dict[str, Any]] = []
+    seen_paths: set[str] = set()
+    for entry in candidates:
+        runtimes = entry.get("runtimes", [])
+        if runtimes and runtime not in runtimes:
+            continue
+        path = entry.get("path")
+        if path in seen_paths:
+            continue
+        seen_paths.add(path)
+        selected.append(entry)
+    return selected
+
+
+def compose_environment(
+    inline_env: Any,
+    secret_env: Sequence[Mapping[str, Any]],
+    *,
+    rotation_timestamp: Optional[str],
+    service_name: Optional[str],
+    primary_service_name: Optional[str],
+    connections_per_second: Optional[Any],
+) -> List[Dict[str, Any]]:
+    inline_entries = ensure_env_entries(inline_env, context="environment")
+    environment: List[Dict[str, Any]] = []
+    names: set[str] = set()
+
+    def add_entry(name: str, value: Any) -> None:
+        if name in names:
+            return
+        environment.append({"name": name, "value": value})
+        names.add(name)
+
+    for entry in inline_entries:
+        add_entry(entry["name"], entry.get("value"))
+
+    if connections_per_second is not None and service_name == primary_service_name:
+        add_entry("CONNECTIONS_PER_SECOND", str(connections_per_second))
+
+    if rotation_timestamp is not None:
+        add_entry("SHMA_SECRETS_ROTATION", rotation_timestamp)
+
+    for entry in secret_env:
+        name = entry.get("name")
+        if not name:
+            continue
+        add_entry(name, f"${{{name}}}")
+
+    return environment
+
+
+def merge_inline_environment(
+    inline_env: Any,
+    *,
+    rotation_timestamp: Optional[str],
+    connections_per_second: Optional[Any],
+    service_name: Optional[str],
+    primary_service_name: Optional[str],
+) -> List[Dict[str, Any]]:
+    inline_entries = ensure_env_entries(inline_env, context="environment")
+    merged: List[Dict[str, Any]] = []
+    names: set[str] = set()
+
+    def add_entry(name: str, value: Any) -> None:
+        if name in names:
+            return
+        merged.append({"name": name, "value": value})
+        names.add(name)
+
+    for entry in inline_entries:
+        add_entry(entry["name"], entry.get("value"))
+
+    if connections_per_second is not None and service_name == primary_service_name:
+        add_entry("CONNECTIONS_PER_SECOND", str(connections_per_second))
+
+    if rotation_timestamp is not None:
+        add_entry("SHMA_SECRETS_ROTATION", rotation_timestamp)
+
+    return merged
+
+
+def health_spec(health: Any | None) -> Dict[str, Any]:
+    command = get_health_command(health)
+    src: Mapping[str, Any] = health or {}
+    spec = {
+        "command": command,
+        "interval": src.get("interval", "10s"),
+        "timeout": src.get("timeout", "5s"),
+        "retries": src.get("retries", 3),
+    }
+    if isinstance(src, Mapping) and src.get("start_period") is not None:
+        spec["start_period"] = src.get("start_period")
+    return spec
+
+
+class FilterModule:
+    def filters(self) -> Dict[str, Any]:
+        return {
+            "as_list": _as_list,
+            "unique": _unique,
+            "ensure_env_entries": ensure_env_entries,
+            "normalize_security": normalize_security,
+            "normalize_secrets": normalize_secrets,
+            "secrets_env_map": secrets_env_map,
+            "normalize_mounts": normalize_mounts,
+            "select_ephemeral_mounts": select_ephemeral_mounts,
+            "compose_environment": compose_environment,
+            "merge_inline_environment": merge_inline_environment,
+            "health_spec": health_spec,
+        }

--- a/roles/common/apply_runtime/tasks/docker.yml
+++ b/roles/common/apply_runtime/tasks/docker.yml
@@ -1,49 +1,16 @@
----
-- name: Resolve Docker secrets
+- name: Prepare Docker secrets
+  include_tasks: prepare_secrets.yml
+  vars:
+    runtime_secret_env_path: null
+    runtime_secret_dir: "{{ runtime_output_dir }}/secrets"
+    runtime_secret_write_env_file: false
+
+- name: Derive Docker secret helpers
   set_fact:
-    compose_secret_env: "{{ secrets.env if secrets is defined and secrets.env is not none and secrets.env | length > 0 else [] }}"
-    compose_secret_env_map: "{{ dict(compose_secret_env | map(attribute='name') | zip(compose_secret_env | map(attribute='value'))) if compose_secret_env | length > 0 else {} }}"
-    compose_secret_files: "{{ secrets.files if secrets is defined and secrets.files is not none and secrets.files | length > 0 else [] }}"
-
-    compose_secret_shred: "{{ secrets.shred_after_apply | default(true) if secrets is defined else true }}"
-
-    compose_secret_env_path: "{{ runtime_output_dir }}/{{ service_name | default(service_id) }}.env"
-
-
-- name: Register Docker secret shredding handler
-  set_fact:
-    runtime_secret_cleanup_contexts: >-
-      {{
-        (runtime_secret_cleanup_contexts | default([]))
-        + [
-          {
-            'env_path': compose_secret_env_path,
-            'env': compose_secret_env,
-            'files': compose_secret_files,
-            'directory': runtime_output_dir + '/secrets',
-            'shred': compose_secret_shred,
-          }
-        ]
-      }}
-  when: compose_secret_env | length > 0 or compose_secret_files | length > 0
-  notify: runtime secret cleanup
-  changed_when: true
-
-- name: Ensure Compose secret directory exists
-  file:
-    path: "{{ runtime_output_dir }}/secrets"
-    state: directory
-    mode: '0700'
-  when: compose_secret_files | length > 0
-
-- name: Write Compose secret files
-  copy:
-    dest: "{{ runtime_output_dir }}/secrets/{{ item.name }}"
-    mode: "{{ item.mode | default('0400') }}"
-    content: "{{ item.value | default(item.content) }}"
-  loop: "{{ compose_secret_files }}"
-  when: compose_secret_files | length > 0
-  no_log: true
+    compose_secret_env: "{{ runtime_secret_context.env }}"
+    compose_secret_env_map: "{{ runtime_secret_context | secrets_env_map }}"
+    compose_secret_files: "{{ runtime_secret_context.files }}"
+    compose_secret_shred: "{{ runtime_secret_context.shred_after_apply }}"
 
 - name: Verify Docker daemon is running
   ansible.builtin.command: docker info

--- a/roles/common/apply_runtime/tasks/podman.yml
+++ b/roles/common/apply_runtime/tasks/podman.yml
@@ -28,73 +28,26 @@
     quadlet_env_path: "{{ ((quadlet_effective_scope == 'user') | ternary(quadlet_user_home + '/.config/containers/systemd', '/etc/containers/systemd')) + '/' + (service_name | default(service_id)) + '.env' }}"
     quadlet_secret_dir: "{{ ((quadlet_effective_scope == 'user') | ternary(quadlet_user_home + '/.config/containers/systemd/secrets', '/etc/containers/systemd/secrets')) }}"
 
-- name: Resolve Quadlet secrets
-  set_fact:
-    quadlet_secret_env: "{{ secrets.env if secrets is defined and secrets.env is not none and secrets.env | length > 0 else [] }}"
-    quadlet_secret_files: "{{ secrets.files if secrets is defined and secrets.files is not none and secrets.files | length > 0 else [] }}"
-    quadlet_secret_shred: "{{ secrets.shred_after_apply if secrets is defined else true }}"
+- name: Prepare Quadlet secrets
+  include_tasks: prepare_secrets.yml
+  vars:
+    runtime_secret_env_path: "{{ quadlet_env_path }}"
+    runtime_secret_dir: "{{ quadlet_secret_dir }}"
+    runtime_secret_write_env_file: true
+    runtime_secret_become: {{ (quadlet_effective_scope == 'system') | bool }}
+    runtime_secret_cleanup_entry_extra:
+      become: {{ (quadlet_effective_scope == 'system') | bool }}
 
-- name: Deduplicate quadlet secret environment variables
+- name: Derive Quadlet secret helpers
   set_fact:
-    quadlet_secret_env: >-
-      {{ quadlet_secret_env | reverse | unique(attribute='name') | reverse }}
-  when: quadlet_secret_env | length > 0
-
-- name: Register Podman secret shredding handler
-  set_fact:
-    runtime_secret_cleanup_contexts: >-
-      {{
-        (runtime_secret_cleanup_contexts | default([]))
-        + [
-          {
-            'env_path': quadlet_env_path,
-            'env': quadlet_secret_env,
-            'files': quadlet_secret_files,
-            'directory': quadlet_secret_dir,
-            'shred': quadlet_secret_shred,
-            'become': (quadlet_effective_scope == 'system') | bool,
-          }
-        ]
-      }}
-  when: quadlet_secret_env | length > 0 or quadlet_secret_files | length > 0
-  notify: runtime secret cleanup
-  changed_when: true
+    quadlet_secret_env: "{{ runtime_secret_context.env }}"
+    quadlet_secret_files: "{{ runtime_secret_context.files }}"
 
 - name: Ensure quadlet directory exists
   file:
     path: "{{ quadlet_base_dir }}"
     state: directory
     mode: '0755'
-  become: {{ (quadlet_effective_scope == 'system') | bool }}
-
-- name: Ensure quadlet secret directory exists
-  file:
-    path: "{{ quadlet_secret_dir }}"
-    state: directory
-    mode: '0700'
-  when: quadlet_secret_files | length > 0
-  become: {{ (quadlet_effective_scope == 'system') | bool }}
-
-- name: Write Quadlet environment file
-  copy:
-    dest: "{{ quadlet_env_path }}"
-    mode: '0600'
-    content: |-
-      {% for item in quadlet_secret_env %}
-      {{ item.name }}={{ item.value }}
-      {% endfor %}
-  when: quadlet_secret_env | length > 0
-  no_log: true
-  become: {{ (quadlet_effective_scope == 'system') | bool }}
-
-- name: Write Quadlet secret files
-  copy:
-    dest: "{{ quadlet_secret_dir }}/{{ item.name }}"
-    mode: "{{ item.mode | default('0400') }}"
-    content: "{{ item.value | default(item.content) }}"
-  loop: "{{ quadlet_secret_files }}"
-  when: quadlet_secret_files | length > 0
-  no_log: true
   become: {{ (quadlet_effective_scope == 'system') | bool }}
 
 - name: Copy Quadlet container file

--- a/roles/common/apply_runtime/tasks/prepare_secrets.yml
+++ b/roles/common/apply_runtime/tasks/prepare_secrets.yml
@@ -1,0 +1,73 @@
+---
+- name: Normalise runtime secrets
+  set_fact:
+    runtime_secret_context: "{{ secrets | default({}) | normalize_secrets }}"
+
+- name: Register runtime secret shredding handler
+  set_fact:
+    runtime_secret_cleanup_contexts: >-
+      {{
+        (runtime_secret_cleanup_contexts | default([]))
+        + [
+          cleanup_entry
+        ]
+      }}
+  vars:
+    cleanup_entry: >-
+      {{
+        {
+          'env': runtime_secret_context.env,
+          'files': runtime_secret_context.files,
+          'shred': runtime_secret_context.shred_after_apply,
+        }
+        | combine(
+          ((runtime_secret_env_path | default(none)) is not none)
+          | ternary({'env_path': runtime_secret_env_path}, {})
+        )
+        | combine(
+          ((runtime_secret_dir | default(none)) is not none)
+          | ternary({'directory': runtime_secret_dir}, {})
+        )
+        | combine(runtime_secret_cleanup_entry_extra | default({}))
+      }}
+  when:
+    - runtime_secret_context.env | length > 0 or runtime_secret_context.files | length > 0
+  notify: runtime secret cleanup
+  changed_when: true
+
+- name: Ensure runtime secret directory exists
+  file:
+    path: "{{ runtime_secret_dir }}"
+    state: directory
+    mode: "{{ runtime_secret_dir_mode | default('0700') }}"
+  when:
+    - runtime_secret_dir is not none
+    - runtime_secret_context.files | length > 0
+  become: {{ runtime_secret_become | default(false) }}
+
+- name: Write runtime secret files
+  copy:
+    dest: "{{ runtime_secret_dir }}/{{ item.name }}"
+    mode: "{{ item.mode | default('0400') }}"
+    content: "{{ item.content | default('') }}"
+  loop: "{{ runtime_secret_context.files }}"
+  when:
+    - runtime_secret_dir is not none
+    - runtime_secret_context.files | length > 0
+  no_log: true
+  become: {{ runtime_secret_become | default(false) }}
+
+- name: Write runtime secret environment file
+  copy:
+    dest: "{{ runtime_secret_env_path }}"
+    mode: "{{ runtime_secret_env_mode | default('0600') }}"
+    content: |-
+      {% for item in runtime_secret_context.env %}
+      {{ item.name }}={{ item.value }}
+      {% endfor %}
+  when:
+    - runtime_secret_write_env_file | default(false)
+    - runtime_secret_env_path is not none
+    - runtime_secret_context.env | length > 0
+  no_log: true
+  become: {{ runtime_secret_become | default(false) }}

--- a/roles/common/validate_schema/tasks/main.yml
+++ b/roles/common/validate_schema/tasks/main.yml
@@ -128,6 +128,11 @@
     - secrets.shred_after_apply is defined
     - not (secrets.shred_after_apply | bool)
 
+- name: Normalize secrets for validation
+  set_fact:
+    validation_secret_context: "{{ secrets | default({}) | normalize_secrets }}"
+  when: secrets is defined
+
 - name: Validate secret environment values are not placeholders
   assert:
     that:
@@ -135,22 +140,37 @@
     fail_msg: >-
       Secret {{ item.name | default('<unnamed>') }} retains placeholder value
       "change-me". Provide a real secret before applying.
-  loop: "{{ secrets.env | default([]) }}"
+  loop: "{{ validation_secret_context.env | default([]) }}"
   loop_control:
     label: "{{ item.name | default('<unnamed>') }}"
-  when: secrets is defined and secrets.env is defined and secrets.env | length > 0
+  when:
+    - validation_secret_context is defined
+    - validation_secret_context.env | length > 0
 
 - name: Validate secret file contents are not placeholders
   assert:
     that:
-      - not ((item.value | default(item.content | default(''))) | lower).startswith('change-me')
+      - not ((item.content | default('')) | lower).startswith('change-me')
     fail_msg: >-
       Secret file {{ item.name | default('<unnamed>') }} retains placeholder value
       "change-me". Replace it with the real secret payload.
-  loop: "{{ secrets.files | default([]) }}"
+  loop: "{{ validation_secret_context.files | default([]) }}"
   loop_control:
     label: "{{ item.name | default('<unnamed>') }}"
-  when: secrets is defined and secrets.files is defined and secrets.files | length > 0
+  when:
+    - validation_secret_context is defined
+    - validation_secret_context.files | length > 0
+
+- name: Validate ingress routes exist when explicitly enabled
+  fail:
+    msg: >-
+      ingress.enabled is true but no ingress.routes entries were provided. Define
+      at least one route or disable ingress for service {{ service_id | default('unknown') }}.
+  when:
+    - ingress is defined
+    - ingress is mapping
+    - (ingress.enabled | default(false)) | bool
+    - (ingress.routes | default([])) | length == 0
 
 - name: Validate ingress route keys are allowed
   assert:
@@ -234,6 +254,24 @@
     - ingress.routes | length > 0
     - item.tls is defined
     - item.tls.acme is defined
+
+- name: Validate Kubernetes ephemeral mounts are writable
+  vars:
+    read_only_ephemeral: >-
+      {{
+        (mounts.ephemeral_mounts | default([]))
+        | selectattr('read_only', 'defined')
+        | selectattr('read_only', 'equalto', true)
+        | list
+      }}
+  fail:
+    msg: >-
+      Kubernetes runtime does not support read_only ephemeral_mounts. Remove the
+      read_only flag from: {{ read_only_ephemeral | map(attribute='name') | join(', ') }}.
+  when:
+    - runtime_templates is defined
+    - runtime_templates.kubernetes is defined
+    - read_only_ephemeral | length > 0
 
 - name: Validate ingress headers keys are allowed
   assert:

--- a/schemas/service.schema.yml
+++ b/schemas/service.schema.yml
@@ -147,6 +147,28 @@ properties:
         minimum: 1
   service_namespace:
     type: string
+  service_network_policy:
+    type: object
+    properties:
+      enabled:
+        type: boolean
+      policy_types:
+        type: array
+        items:
+          type: string
+          enum: [Ingress, Egress]
+      ingress:
+        type: array
+        items:
+          type: object
+      egress:
+        type: array
+        items:
+          type: object
+    description: >-
+      Optional overrides for the generated Kubernetes NetworkPolicy. When
+      omitted the renderer emits a strict default that allows ingress from the
+      service namespace and unrestricted egress.
   service_replicas:
     type: integer
   service_storage_gb:
@@ -297,6 +319,12 @@ properties:
               items:
                 type: string
                 enum: [docker, podman, kubernetes, proxmox, baremetal]
+              deprecated: true
+            runtimes:
+              type: array
+              items:
+                type: string
+                enum: [docker, podman, kubernetes, proxmox, baremetal]
             medium:
               type: string
             size:
@@ -327,6 +355,31 @@ properties:
         default: true
       rotation_timestamp:
         type: string
+      items:
+        type: array
+        items:
+          type: object
+          required:
+            - name
+          properties:
+            name:
+              type: string
+            type:
+              type: string
+              enum: [env, file]
+            value:
+              type: string
+            content:
+              type: string
+            target:
+              type: string
+            mode:
+              type: string
+        description: >-
+          Unified secret declarations. Each entry must declare a ``name`` and
+          either provide a ``value`` for environment variables or ``content`` for
+          file-based secrets. The optional ``type`` field defaults to ``env`` when
+          omitted.
       env:
         type: array
         items:
@@ -337,6 +390,7 @@ properties:
               type: string
             value:
               type: string
+        deprecated: true
       files:
         type: array
         items:
@@ -353,6 +407,7 @@ properties:
               type: string
             mode:
               type: string
+        deprecated: true
       shred_waiver_reason:
         type: string
         description: >-

--- a/templates/_common.j2
+++ b/templates/_common.j2
@@ -2,31 +2,13 @@
   Helper macro to provide shared runtime defaults.
 #}
 
-{% macro with_defaults(service_security=None, secrets=None) -%}
-  {% set security = service_security | default({}) %}
-  {% set drop_caps = security.capabilities_drop | default(['ALL']) %}
-  {% if drop_caps is string %}{% set drop_caps = [drop_caps] %}{% endif %}
-  {% set bounding = security.capability_bounding_set if security.capability_bounding_set is defined else [] %}
-  {% if bounding is string %}{% set bounding = [bounding] %}{% endif %}
-  {% set defaults = {
-    'run_user': security.run_as_user if security.run_as_user is defined else 65532,
-    'run_group': security.run_as_group if security.run_as_group is defined else (security.run_as_user if security.run_as_user is defined else 65532),
-    'read_only_root': security.read_only_root_filesystem if security.read_only_root_filesystem is defined else true,
-    'capabilities_drop': drop_caps,
-    'no_new_privileges': security.no_new_privileges if security.no_new_privileges is defined else true,
-    'apparmor_profile': security.apparmor_profile if security.apparmor_profile is defined else 'docker-default',
-    'allow_privilege_escalation': security.allow_privilege_escalation if security.allow_privilege_escalation is defined else not (security.no_new_privileges if security.no_new_privileges is defined else true),
-    'compose_user': security.user if security.user is defined else none,
-    'capability_bounding_set': bounding
-  } %}
+{% macro service_context(service_security=None, secrets=None, mounts=None) -%}
+  {% set security_defaults = service_security | default({}) | normalize_security %}
+  {% set secret_context = secrets | default({}) | normalize_secrets %}
+  {% set mount_context = mounts | default({}) | normalize_mounts %}
+  {{ caller(security_defaults, secret_context, mount_context) }}
+{%- endmacro %}
 
-  {% set secret_source = secrets | default({}) %}
-  {% set env_items = secret_source.env if secret_source.env is not none else [] %}
-  {% set file_items = secret_source.files if secret_source.files is not none else [] %}
-  {% set catalog = {
-    'env_names': env_items | map(attribute='name') | reject('equalto', None) | list,
-    'file_names': file_items | map(attribute='name') | reject('equalto', None) | list
-  } %}
-
-  {{ caller(defaults, catalog) }}
+{% macro health_defaults(health) -%}
+  {{ return(health | health_spec) }}
 {%- endmacro %}

--- a/templates/baremetal.yml.j2
+++ b/templates/baremetal.yml.j2
@@ -1,3 +1,9 @@
+{% from '_common.j2' import service_context %}
+{% set _ctx = namespace(security=None, mounts=None) %}
+{% call(security_defaults, _, mount_context) service_context(service_security, secrets, mounts) %}
+  {% set _ctx.security = security_defaults %}
+  {% set _ctx.mounts = mount_context %}
+{% endcall %}
 {% set unit = service_unit | default({}) %}
 {% set description = unit.description | default('Managed service for ' ~ (service_name | default(service_id))) %}
 {% set after = unit.after | default(['network.target']) %}
@@ -5,18 +11,13 @@
 {% set install_targets = unit.install_wanted_by | default(['multi-user.target']) %}
 {% set security = service_security | default({}) %}
 {% set restart_config = service_restart | default({}) %}
-{% set mounts_config = mounts | default({}) %}
-{% set ephemeral_mounts = mounts_config.ephemeral_mounts | default([]) %}
-{% set default_apply_targets = ['docker', 'podman', 'kubernetes', 'proxmox', 'baremetal'] %}
+{% set baremetal_mounts = _ctx.mounts.ephemeral | select_ephemeral_mounts('baremetal') %}
 {% set baremetal_tmpfs = namespace(items=[]) %}
-{% for mount in ephemeral_mounts %}
-  {% set apply_targets = mount.apply_to | default(default_apply_targets) %}
-  {% if 'baremetal' in apply_targets %}
-    {% set options = [] %}
-    {% if mount.size is defined %}{% set _ = options.append('size=' ~ mount.size) %}{% endif %}
-    {% if mount.mode is defined %}{% set _ = options.append('mode=' ~ mount.mode) %}{% endif %}
-    {% set _ = baremetal_tmpfs.items.append({'path': mount.path, 'options': options}) %}
-  {% endif %}
+{% for mount in baremetal_mounts %}
+  {% set options = [] %}
+  {% if mount.size is not none %}{% set _ = options.append('size=' ~ mount.size) %}{% endif %}
+  {% if mount.mode is not none %}{% set _ = options.append('mode=' ~ mount.mode) %}{% endif %}
+  {% set _ = baremetal_tmpfs.items.append({'path': mount.path, 'options': options}) %}
 {% endfor %}
 {% macro systemd_toggle(value, true_value='yes', false_value='no') -%}
   {%- if value is boolean -%}
@@ -25,7 +26,7 @@
     {{ value }}
   {%- endif -%}
 {%- endmacro %}
-{% set read_only_root = security.read_only_root_filesystem if security.read_only_root_filesystem is defined else true %}
+{% set read_only_root = _ctx.security.read_only_root %}
 {% set private_tmp_default = security.private_tmp if security.private_tmp is defined else true %}
 {% set protect_system_default = security.protect_system if security.protect_system is defined else (read_only_root | ternary('strict', 'full')) %}
 {% set protect_home_default = security.protect_home if security.protect_home is defined else 'yes' %}

--- a/templates/docker.yml.j2
+++ b/templates/docker.yml.j2
@@ -1,38 +1,32 @@
-{% from '_common.j2' import with_defaults %}
-{% set _defaults_ctx = namespace(security=None, catalog=None) %}
-{% call(defaults, catalog) with_defaults(service_security, secrets) %}
-  {% set _defaults_ctx.security = defaults %}
-  {% set _defaults_ctx.catalog = catalog %}
+{% from '_common.j2' import service_context %}
+{% set _ctx = namespace(security=None, secrets=None, mounts=None) %}
+{% call(security_defaults, secret_context, mount_context) service_context(service_security, secrets, mounts) %}
+  {% set _ctx.security = security_defaults %}
+  {% set _ctx.secrets = secret_context %}
+  {% set _ctx.mounts = mount_context %}
 {% endcall %}
-{%- set shma_security_defaults = _defaults_ctx.security %}
-{%- set shma_secret_catalog = _defaults_ctx.catalog %}
-{%- set mounts_config = mounts | default({}) %}
-{%- set ephemeral_mounts = mounts_config.ephemeral_mounts | default([]) %}
-{%- set default_apply_targets = ['docker', 'podman', 'kubernetes', 'proxmox', 'baremetal'] %}
-{%- set security = service_security | default({}) %}
-{%- set default_run_user = security.run_as_user if security.run_as_user is defined else 65532 %}
-{%- set default_run_group = security.run_as_group if security.run_as_group is defined else default_run_user %}
-{%- set compose_user_default = security.user if security.user is defined else ((default_run_user | string) ~ ':' ~ (default_run_group | string)) %}
-{%- set read_only_root = security.read_only_root_filesystem if security.read_only_root_filesystem is defined else true %}
-{%- set drop_caps_default = security.capabilities_drop | default(['ALL']) %}
-{%- if drop_caps_default is string %}{%- set drop_caps_default = [drop_caps_default] %}{%- endif %}
-{%- set no_new_privs = security.no_new_privileges if security.no_new_privileges is defined else true %}
-{%- set default_apparmor = security.apparmor_profile if security.apparmor_profile is defined else 'docker-default' %}
-{%- set allowed_apparmor_profiles = security.allowed_apparmor_profiles if security.allowed_apparmor_profiles is defined else ['docker-default', 'unconfined'] %}
-{%- if allowed_apparmor_profiles is string %}{%- set allowed_apparmor_profiles = [allowed_apparmor_profiles] %}{%- endif %}
+{%- set shma_security_defaults = _ctx.security %}
+{%- set shma_secret_context = _ctx.secrets %}
+{%- set shma_secret_catalog = shma_secret_context.catalog %}
+{%- set docker_ephemeral_mounts = _ctx.mounts.ephemeral | select_ephemeral_mounts('docker') %}
+{%- set default_run_user = shma_security_defaults.run_user %}
+{%- set default_run_group = shma_security_defaults.run_group %}
+{%- set compose_user_default = shma_security_defaults.compose_user if shma_security_defaults.compose_user is not none else ((default_run_user | string) ~ ':' ~ (default_run_group | string)) %}
+{%- set read_only_root = shma_security_defaults.read_only_root %}
+{%- set drop_caps_default = shma_security_defaults.capabilities_drop %}
+{%- set no_new_privs = shma_security_defaults.no_new_privileges %}
+{%- set default_apparmor = shma_security_defaults.apparmor_profile %}
+{%- set allowed_apparmor_profiles = shma_security_defaults.allowed_apparmor_profiles %}
 {%- set defined_secret_env_names = shma_secret_catalog.env_names | default([]) %}
 {%- set defined_file_secret_names = shma_secret_catalog.file_names | default([]) %}
 {%- set docker_tmpfs = namespace(items=[]) %}
-{%- for mount in ephemeral_mounts %}
-  {%- set apply_targets = mount.apply_to | default(default_apply_targets) %}
-  {%- if 'docker' in apply_targets %}
-    {%- set options = [] %}
-    {%- if mount.size is defined %}{%- set _ = options.append('size=' ~ mount.size) %}{%- endif %}
-    {%- if mount.mode is defined %}{%- set _ = options.append('mode=' ~ mount.mode) %}{%- endif %}
-    {%- set entry = mount.path %}
-    {%- if options %}{%- set entry = entry ~ ':' ~ options | join(',') %}{%- endif %}
-    {%- if entry not in docker_tmpfs.items %}{%- set _ = docker_tmpfs.items.append(entry) %}{%- endif %}
-  {%- endif %}
+{%- for mount in docker_ephemeral_mounts %}
+  {%- set options = [] %}
+  {%- if mount.size is not none %}{%- set _ = options.append('size=' ~ mount.size) %}{%- endif %}
+  {%- if mount.mode is not none %}{%- set _ = options.append('mode=' ~ mount.mode) %}{%- endif %}
+  {%- set entry = mount.path %}
+  {%- if options %}{%- set entry = entry ~ ':' ~ options | join(',') %}{%- endif %}
+  {%- if entry not in docker_tmpfs.items %}{%- set _ = docker_tmpfs.items.append(entry) %}{%- endif %}
 {%- endfor %}
 {% set services_list = services | default([{ 
   'name': service_name | default(service_id),
@@ -46,9 +40,9 @@
 {% set resources = service_resources | default({}) %}
 {% set connections_per_second = resources.connections_per_second if resources.connections_per_second is defined else None %}
 {% set primary_service_name = service_name | default(service_id) %}
-{% set secret_env = secrets.env if secrets is defined and secrets.env is not none and secrets.env | length > 0 else [] %}
-{% set file_secrets = secrets.files if secrets is defined and secrets.files is not none and secrets.files | length > 0 else [] %}
-{% set rotation_timestamp = secrets.rotation_timestamp if secrets is defined and secrets.rotation_timestamp is not none else None %}
+{% set secret_env = shma_secret_context.env %}
+{% set file_secrets = shma_secret_context.files %}
+{% set rotation_timestamp = shma_secret_context.rotation_timestamp %}
 {% set docker_defaults = {
   'compose_user_default': compose_user_default,
   'read_only_root': read_only_root,
@@ -62,7 +56,7 @@
   'connections_per_second': connections_per_second,
   'primary_service_name': primary_service_name,
   'rotation_timestamp': rotation_timestamp,
-  'default_init': security.init if security.init is defined else None
+  'default_init': shma_security_defaults.init,
 } %}
 {% set prepared_services = services_list | docker_compose_prepare_services(docker_defaults) %}
 services:

--- a/templates/kubernetes.yml.j2
+++ b/templates/kubernetes.yml.j2
@@ -1,16 +1,15 @@
 #jinja2: lstrip_blocks: True, trim_blocks: True
-{% from '_common.j2' import with_defaults %}
-{% set _defaults_ctx = namespace(security=None, catalog=None) %}
-{% call(defaults, catalog) with_defaults(service_security, secrets) %}
-  {% set _defaults_ctx.security = defaults %}
-  {% set _defaults_ctx.catalog = catalog %}
+{% from '_common.j2' import service_context %}
+{% set _ctx = namespace(security=None, secrets=None, mounts=None) %}
+{% call(security_defaults, secret_context, mount_context) service_context(service_security, secrets, mounts) %}
+  {% set _ctx.security = security_defaults %}
+  {% set _ctx.secrets = secret_context %}
+  {% set _ctx.mounts = mount_context %}
 {% endcall %}
-{% set shma_security_defaults = _defaults_ctx.security %}
+{% set shma_security_defaults = _ctx.security %}
+{% set shma_secret_context = _ctx.secrets %}
 {% set svc_name = service_name | default(service_id) %}
 {% set svc_namespace = service_namespace | default('default') %}
-{% set mounts_config = mounts | default({}) %}
-{% set ephemeral_mounts = mounts_config.ephemeral_mounts | default([]) %}
-{% set default_apply_targets = ['docker', 'podman', 'kubernetes', 'proxmox', 'baremetal'] %}
 {% set default_run_user = shma_security_defaults.run_user %}
 {% set default_run_group = shma_security_defaults.run_group %}
 {% set read_only_root = shma_security_defaults.read_only_root %}
@@ -22,38 +21,38 @@
 {% set ingress_flag = ingress_spec.get('enabled') if ingress_spec is mapping else none %}
 {% set ingress_enabled = (ingress_flag if ingress_flag is not none else (ingress_routes | length > 0)) %}
 {% set k8s_ephemeral = namespace(items=[]) %}
-{% for mount in ephemeral_mounts %}
-  {% set apply_targets = mount.apply_to | default(default_apply_targets) %}
-  {% if 'kubernetes' in apply_targets %}
-    {% set volume_name = mount.name | default('ephemeral-' ~ loop.index) %}
-    {% set entry = {
-      'volume_name': volume_name,
-      'mount_path': mount.path,
-      'medium': mount.medium | default('Memory'),
-      'size': mount.size if mount.size is defined else None,
-      'read_only': mount.read_only if mount.read_only is defined else false
-    } %}
-    {% set _ = k8s_ephemeral.items.append(entry) %}
-  {% endif %}
+{% set kubernetes_ephemeral_mounts = _ctx.mounts.ephemeral | select_ephemeral_mounts('kubernetes') %}
+{% for mount in kubernetes_ephemeral_mounts %}
+  {% set volume_name = mount.name | default('ephemeral-' ~ loop.index) %}
+  {% set entry = {
+    'volume_name': volume_name,
+    'mount_path': mount.path,
+    'medium': mount.medium | default('Memory'),
+    'size': mount.size,
+    'read_only': mount.read_only
+  } %}
+  {% set _ = k8s_ephemeral.items.append(entry) %}
 {% endfor %}
-{% set secret_env = secrets.env if secrets is defined and secrets.env is not none and secrets.env | length > 0 else [] %}
-{% set file_secrets = secrets.files if secrets is defined and secrets.files is not none and secrets.files | length > 0 else [] %}
-{% set inline_env = service_env | default([]) | list %}
-{% set inline_env_ns = namespace(items=inline_env) %}
+{% set secret_env = shma_secret_context.env %}
+{% set file_secrets = shma_secret_context.files %}
 {% set env_secret_name = svc_name + '-env' %}
 {% set file_secret_name = svc_name + '-files' %}
-{% set health_cmd = health | health_command %}
-{% set health_interval_seconds = (health.interval | default('10s')) | regex_replace('s$', '') | int %}
-{% set health_timeout_seconds = (health.timeout | default('5s')) | regex_replace('s$', '') | int %}
-{% set health_retries = health.retries | default(3) %}
+{% set health_details = health | health_spec %}
+{% set health_cmd = health_details.command %}
+{% set health_interval_seconds = (health_details.interval | regex_replace('s$', '')) | int %}
+{% set health_timeout_seconds = (health_details.timeout | regex_replace('s$', '')) | int %}
+{% set health_retries = health_details.retries %}
 {% set replicas = service_replicas | default(1) %}
 {% set ports = service_ports | default([]) %}
-{% set container_port = ports[0].target if ports | length > 0 else 8080 %}
-{% set service_port_value = ports[0].published if ports | length > 0 and ports[0].published is defined else container_port %}
+{% set primary_port = ports[0] if ports | length > 0 else none %}
+{% set container_port = primary_port.target if primary_port is not none else none %}
+{% set service_port_value = primary_port.published if primary_port is not none and primary_port.published is defined else (primary_port.target if primary_port is not none else none) %}
 {% set resources = service_resources | default({'memory_mb': 256, 'cpu_cores': 1}) %}
 {% set memory_request = resources.memory_mb | default(256) %}
 {% set cpu_cores = resources.cpu_cores | default(1) %}
 {% set connections_per_second = resources.connections_per_second if resources.connections_per_second is defined else None %}
+{% set inline_env = service_env | merge_inline_environment(rotation_timestamp=shma_secret_context.rotation_timestamp, connections_per_second=connections_per_second, service_name=svc_name, primary_service_name=svc_name) %}
+{% set inline_env_ns = namespace(items=inline_env) %}
 {% set volume_config = service_volumes[0] if service_volumes is defined and service_volumes | length > 0 else None %}
 {% set use_host_path = volume_config is mapping and volume_config.host_path is defined %}
 {% set host_path = volume_config.host_path if use_host_path else None %}
@@ -123,9 +122,9 @@ spec:
     metadata:
       labels:
         app: {{ svc_name }}
-{% if secrets is defined and secrets.rotation_timestamp is defined and secrets.rotation_timestamp is not none %}
+{% if shma_secret_context.rotation_timestamp is not none %}
       annotations:
-        shma.dev/secrets-rotation: "{{ secrets.rotation_timestamp }}"
+        shma.dev/secrets-rotation: "{{ shma_secret_context.rotation_timestamp }}"
 {% endif %}
     spec:
       securityContext:
@@ -145,12 +144,6 @@ spec:
 {% for cap in drop_caps_default %}
                 - {{ cap }}
 {% endfor %}
-{% endif %}
-{% if secrets is defined and secrets.rotation_timestamp is defined and secrets.rotation_timestamp is not none %}
-  {% set _ = inline_env_ns.items.append({'name': 'SHMA_SECRETS_ROTATION', 'value': secrets.rotation_timestamp | string}) %}
-{% endif %}
-{% if connections_per_second is not none %}
-  {% set _ = inline_env_ns.items.append({'name': 'CONNECTIONS_PER_SECOND', 'value': connections_per_second | string}) %}
 {% endif %}
 {% set inline_env = inline_env_ns.items %}
 {% set has_secret_env = secret_env | length > 0 %}
@@ -173,8 +166,10 @@ spec:
 {% endfor %}
 {% endif %}
 {% endif %}
+{% if container_port is not none %}
           ports:
             - containerPort: {{ container_port }}
+{% endif %}
           volumeMounts:
             - name: data
               mountPath: {{ volume_mount_path }}
@@ -247,6 +242,7 @@ spec:
                 path: {{ secret.name }}
 {% endfor %}
 {% endif %}
+{% if container_port is not none and service_port_value is not none %}
 ---
 apiVersion: v1
 kind: Service
@@ -300,5 +296,37 @@ spec:
         - {{ host }}
 {% endfor %}
 {% endfor %}
+{% endif %}
+{% endif %}
+{% endif %}
+{% set network_policy_config = service_network_policy | default({}) %}
+{% set network_policy_enabled = network_policy_config.enabled if network_policy_config.enabled is defined else true %}
+{% if network_policy_enabled %}
+{% set policy_types = (network_policy_config.policy_types | default(['Ingress', 'Egress'])) | unique %}
+{% set default_ingress_rules = [{'from': [{'namespaceSelector': {'matchLabels': {'kubernetes.io/metadata.name': svc_namespace}}}]}] %}
+{% set default_egress_rules = [{'to': [{'namespaceSelector': {}}]}] %}
+{% set ingress_rules = network_policy_config.ingress | default(default_ingress_rules) %}
+{% set egress_rules = network_policy_config.egress | default(default_egress_rules) %}
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ svc_name }}
+  namespace: {{ svc_namespace }}
+spec:
+  podSelector:
+    matchLabels:
+      app: {{ svc_name }}
+  policyTypes:
+{% for policy in policy_types %}
+    - {{ policy }}
+{% endfor %}
+{% if 'Ingress' in policy_types %}
+  ingress:
+{{ ingress_rules | to_nice_yaml(indent=4) | indent(4) }}
+{% endif %}
+{% if 'Egress' in policy_types %}
+  egress:
+{{ egress_rules | to_nice_yaml(indent=4) | indent(4) }}
 {% endif %}
 {% endif %}

--- a/templates/podman.yml.j2
+++ b/templates/podman.yml.j2
@@ -1,13 +1,13 @@
-{% from '_common.j2' import with_defaults %}
-{% set _defaults_ctx = namespace(security=None, catalog=None) %}
-{% call(defaults, catalog) with_defaults(service_security, secrets) %}
-  {% set _defaults_ctx.security = defaults %}
-  {% set _defaults_ctx.catalog = catalog %}
+{% from '_common.j2' import service_context %}
+{% set _ctx = namespace(security=None, secrets=None, mounts=None) %}
+{% call(security_defaults, secret_context, mount_context) service_context(service_security, secrets, mounts) %}
+  {% set _ctx.security = security_defaults %}
+  {% set _ctx.secrets = secret_context %}
+  {% set _ctx.mounts = mount_context %}
 {% endcall %}
-{% set shma_security_defaults = _defaults_ctx.security %}
-{% set mounts_config = mounts | default({}) %}
-{% set ephemeral_mounts = mounts_config.ephemeral_mounts | default([]) %}
-{% set default_apply_targets = ['docker', 'podman', 'kubernetes', 'proxmox', 'baremetal'] %}
+{% set shma_security_defaults = _ctx.security %}
+{% set shma_secret_context = _ctx.secrets %}
+{% set podman_ephemeral_mounts = _ctx.mounts.ephemeral | select_ephemeral_mounts('podman') %}
 {% set default_run_user = shma_security_defaults.run_user %}
 {% set default_run_group = shma_security_defaults.run_group %}
 {% set quadlet_user = shma_security_defaults.compose_user if shma_security_defaults.compose_user is not none else ((default_run_user | string) ~ ':' ~ (default_run_group | string)) %}
@@ -17,34 +17,31 @@
 {% set bounding_set = shma_security_defaults.capability_bounding_set %}
 {% set tmpfs_hardening_flags = ['nosuid', 'nodev', 'noexec'] %}
 {% set podman_tmpfs = namespace(entries=[]) %}
-{% for mount in ephemeral_mounts %}
-  {% set apply_targets = mount.apply_to | default(default_apply_targets) %}
-  {% if 'podman' in apply_targets %}
-    {% set existing = none %}
-    {% for item in podman_tmpfs.entries %}
-      {% if item.path == mount.path %}
-        {% set existing = item %}
-      {% endif %}
-    {% endfor %}
-    {% if existing is none %}
-      {% set existing = namespace(path=mount.path, options=[]) %}
-      {% set _ = podman_tmpfs.entries.append(existing) %}
+{% for mount in podman_ephemeral_mounts %}
+  {% set existing = none %}
+  {% for item in podman_tmpfs.entries %}
+    {% if item.path == mount.path %}
+      {% set existing = item %}
     {% endif %}
-    {% for flag in tmpfs_hardening_flags %}
-      {% if flag not in existing.options %}{% set _ = existing.options.append(flag) %}{% endif %}
-    {% endfor %}
-    {% if mount.size is defined %}
-      {% set size_flag = 'size=' ~ mount.size %}
-      {% if size_flag not in existing.options %}{% set _ = existing.options.append(size_flag) %}{% endif %}
-    {% endif %}
-    {% if mount.mode is defined %}
-      {% set mode_flag = 'mode=' ~ mount.mode %}
-      {% if mode_flag not in existing.options %}{% set _ = existing.options.append(mode_flag) %}{% endif %}
-    {% endif %}
+  {% endfor %}
+  {% if existing is none %}
+    {% set existing = namespace(path=mount.path, options=[]) %}
+    {% set _ = podman_tmpfs.entries.append(existing) %}
+  {% endif %}
+  {% for flag in tmpfs_hardening_flags %}
+    {% if flag not in existing.options %}{% set _ = existing.options.append(flag) %}{% endif %}
+  {% endfor %}
+  {% if mount.size is not none %}
+    {% set size_flag = 'size=' ~ mount.size %}
+    {% if size_flag not in existing.options %}{% set _ = existing.options.append(size_flag) %}{% endif %}
+  {% endif %}
+  {% if mount.mode is not none %}
+    {% set mode_flag = 'mode=' ~ mount.mode %}
+    {% if mode_flag not in existing.options %}{% set _ = existing.options.append(mode_flag) %}{% endif %}
   {% endif %}
 {% endfor %}
-{% set secret_env = secrets.env if secrets is defined and secrets.env is not none and secrets.env | length > 0 else [] %}
-{% set file_secrets = secrets.files if secrets is defined and secrets.files is not none and secrets.files | length > 0 else [] %}
+{% set secret_env = shma_secret_context.env %}
+{% set file_secrets = shma_secret_context.files %}
 {% set quadlet_scope_value = quadlet_scope | default('system') %}
 {% if quadlet_scope_value == 'user' %}
 {% set quadlet_base_dir = '%h/.config/containers/systemd' %}
@@ -55,15 +52,13 @@
 {% set secret_dir = quadlet_base_dir ~ '/secrets' %}
 {% set ports = service_ports | default([]) %}
 {% set volumes = service_volumes | default([]) %}
-{% set inline_env = service_env | default([]) %}
-{% set inline_env_names = inline_env | map(attribute='name') | list %}
 {% set resources = service_resources | default({}) %}
+{% set connections_per_second = resources.connections_per_second if resources.connections_per_second is defined else None %}
+{% set inline_env = service_env | merge_inline_environment(rotation_timestamp=shma_secret_context.rotation_timestamp, connections_per_second=connections_per_second, service_name=service_name | default(service_id), primary_service_name=service_name | default(service_id)) %}
+{% set inline_env_names = inline_env | map(attribute='name') | list %}
 {% set user_namespace = security.user_namespace if security.user_namespace is defined else none %}
-{% if resources.connections_per_second is defined %}
-  {% set inline_env = inline_env + [{'name': 'CONNECTIONS_PER_SECOND', 'value': resources.connections_per_second | string}] %}
-{% endif %}
 {% set auto_update_mode = quadlet_auto_update | default('none') %}
-{% set health_cmd = health | health_command %}
+{% set health_details = health | health_spec %}
 [Unit]
 Description={{ unit_description }}
 After=network-online.target
@@ -85,9 +80,6 @@ UserNS={{ user_namespace }}
 {% for env in inline_env %}
 Environment={{ env.name }}={{ env.value }}
 {% endfor %}
-{% if secrets is defined and secrets.rotation_timestamp is defined and secrets.rotation_timestamp is not none and 'SHMA_SECRETS_ROTATION' not in inline_env_names %}
-Environment=SHMA_SECRETS_ROTATION={{ secrets.rotation_timestamp }}
-{% endif %}
 {% if secret_env %}
 EnvironmentFile={{ env_file_path }}
 {% endif %}
@@ -109,10 +101,10 @@ Tmpfs={{ tmpfs_value }}
 {% for port in ports %}
 PublishPort={{ port.host_ip | default('') }}{% if port.host_ip is defined and port.host_ip | string | length > 0 %}:{% endif %}{{ port.published | default(port.target) }}:{{ port.target }}{% if port.protocol is defined %}/{{ port.protocol }}{% endif %}
 {% endfor %}
-HealthCmd={{ health_cmd | join(' ') }}
-HealthInterval={{ health.interval | default('10s') }}
-HealthTimeout={{ health.timeout | default('5s') }}
-HealthRetries={{ health.retries | default(3) }}
+HealthCmd={{ health_details.command | join(' ') }}
+HealthInterval={{ health_details.interval }}
+HealthTimeout={{ health_details.timeout }}
+HealthRetries={{ health_details.retries }}
 
 [Service]
 Restart=always

--- a/templates/proxmox.yml.j2
+++ b/templates/proxmox.yml.j2
@@ -1,21 +1,21 @@
 ---
+{% from '_common.j2' import service_context %}
+{% set _ctx = namespace(mounts=None) %}
+{% call(_, _, mount_context) service_context(service_security, secrets, mounts) %}
+  {% set _ctx.mounts = mount_context %}
+{% endcall %}
 {% set container = service_container | default({}) %}
 {% set pkg_list = service_packages | default([]) %}
 {% set file_list = service_files | default([]) %}
 {% set svc_list = service_services | default([]) %}
 {% set cmd_list = service_commands | default([]) %}
-{% set mounts_config = mounts | default({}) %}
-{% set ephemeral_mounts = mounts_config.ephemeral_mounts | default([]) %}
-{% set default_apply_targets = ['docker', 'podman', 'kubernetes', 'proxmox', 'baremetal'] %}
+{% set proxmox_mounts = _ctx.mounts.ephemeral | select_ephemeral_mounts('proxmox') %}
 {% set proxmox_tmpfs = namespace(items=[]) %}
-{% for mount in ephemeral_mounts %}
-  {% set apply_targets = mount.apply_to | default(default_apply_targets) %}
-  {% if 'proxmox' in apply_targets %}
-    {% set options = [] %}
-    {% if mount.mode is defined %}{% set _ = options.append('mode=' ~ mount.mode) %}{% endif %}
-    {% if mount.size is defined %}{% set _ = options.append('size=' ~ mount.size) %}{% endif %}
-    {% set _ = proxmox_tmpfs.items.append({'path': mount.path, 'options': options}) %}
-  {% endif %}
+{% for mount in proxmox_mounts %}
+  {% set options = [] %}
+  {% if mount.mode is not none %}{% set _ = options.append('mode=' ~ mount.mode) %}{% endif %}
+  {% if mount.size is not none %}{% set _ = options.append('size=' ~ mount.size) %}{% endif %}
+  {% set _ = proxmox_tmpfs.items.append({'path': mount.path, 'options': options}) %}
 {% endfor %}
 {% set pkg_names = namespace(items=[]) %}
 {% for pkg in pkg_list %}

--- a/tests/sample_service.yml
+++ b/tests/sample_service.yml
@@ -69,13 +69,11 @@ mounts:
   ephemeral_mounts:
     - name: runtime-run
       path: /run/sample-service
-      apply_to: [docker, podman, kubernetes, proxmox, baremetal]
       medium: Memory
       size: 64Mi
       mode: '0755'
     - name: runtime-tmp
       path: /tmp/sample-service
-      apply_to: [docker, podman]
       size: 64Mi
 health:
   cmd:
@@ -94,12 +92,13 @@ runtime_templates:
 secrets:
   shred_after_apply: true
   rotation_timestamp: "2024-08-20T12:34:56Z"
-  env:
+  items:
     - name: SAMPLE_SERVICE_TOKEN
+      type: env
       value: super-secret-token
-  files:
     - name: tls-cert
-      value: |
+      type: file
+      content: |
         -----BEGIN CERTIFICATE-----
         MIIDdzCCAl+gAwIBAgIEbPOjhzANBgkqhkiG9w0BAQsFADBvMQswCQYDVQQGEwJVUzEQ
         MA4GA1UECBMHQXJpem9uYTEPMA0GA1UEBxMGVG9ycmVzMRQwEgYDVQQKEwtFeGFtcGxl

--- a/tests/samples/full.yml
+++ b/tests/samples/full.yml
@@ -68,13 +68,11 @@ mounts:
   ephemeral_mounts:
     - name: runtime-run
       path: /run/sample-service
-      apply_to: [docker, podman, kubernetes, proxmox, baremetal]
       medium: Memory
       size: 64Mi
       mode: '0755'
     - name: runtime-tmp
       path: /tmp/sample-service
-      apply_to: [docker, podman]
       size: 64Mi
 health:
   cmd:
@@ -92,11 +90,12 @@ runtime_templates:
   baremetal: ../templates/baremetal.yml.j2
 secrets:
   shred_after_apply: true
-  env:
+  items:
     - name: SAMPLE_SERVICE_TOKEN
+      type: env
       value: super-secret-token
-  files:
     - name: tls-cert
-      value: "-----BEGIN CERTIFICATE-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAtestcertificate\n-----END CERTIFICATE-----"
+      type: file
+      content: "-----BEGIN CERTIFICATE-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAtestcertificate\n-----END CERTIFICATE-----"
       target: /etc/sample-service/certs/tls.crt
       mode: '0400'

--- a/tests/samples/with_pvc.yml
+++ b/tests/samples/with_pvc.yml
@@ -39,7 +39,6 @@ mounts:
   ephemeral_mounts:
     - name: runtime-run
       path: /run/pvc
-      apply_to: [docker, podman, kubernetes, proxmox, baremetal]
       medium: Memory
       size: 128Mi
 health:
@@ -55,5 +54,4 @@ kubernetes:
     storageClassName: fast
 secrets:
   shred_after_apply: true
-  env: []
-  files: []
+  items: []

--- a/tests/samples/with_secrets.yml
+++ b/tests/samples/with_secrets.yml
@@ -35,7 +35,6 @@ mounts:
   ephemeral_mounts:
     - name: runtime-run
       path: /run/secure
-      apply_to: [docker, podman, kubernetes, proxmox, baremetal]
       medium: Memory
       size: 96Mi
 health:
@@ -46,11 +45,12 @@ health:
 needs_container_runtime: true
 secrets:
   shred_after_apply: true
-  env:
+  items:
     - name: SECURE_TOKEN
+      type: env
       value: super-secure-token
-  files:
     - name: tls-key
-      value: secret-tls-key
+      type: file
+      content: secret-tls-key
       target: /etc/ssl/private/tls.key
       mode: '0400'

--- a/tests/verify_kubernetes_manifest.yml
+++ b/tests/verify_kubernetes_manifest.yml
@@ -38,6 +38,7 @@
         env_secret_resources: "{{ kubernetes_resources | selectattr('kind', '==', 'Secret') | selectattr('metadata.name', '==', deployment_name ~ '-env') | list }}"
         file_secret_resources: "{{ kubernetes_resources | selectattr('kind', '==', 'Secret') | selectattr('metadata.name', '==', deployment_name ~ '-files') | list }}"
         pvc_resources: "{{ kubernetes_resources | selectattr('kind', '==', 'PersistentVolumeClaim') | list }}"
+        network_policy_resources: "{{ kubernetes_resources | selectattr('kind', '==', 'NetworkPolicy') | list }}"
 
     - name: Validate environment secret layout
       ansible.builtin.assert:
@@ -135,6 +136,16 @@
           - data_volume_entries | length == 1
           - data_volume_entries[0].hostPath.path == service_volumes[0].host_path
         fail_msg: "HostPath volume should back the primary data mount."
+
+    - name: Validate network policy defaults
+      ansible.builtin.assert:
+        that:
+          - network_policy_resources | length == 1
+          - network_policy_resources[0].spec.podSelector.matchLabels.app == service_name | default(service_id)
+          - 'Ingress' in network_policy_resources[0].spec.policyTypes
+          - 'Egress' in network_policy_resources[0].spec.policyTypes
+          - network_policy_resources[0].spec.ingress[0].from[0].namespaceSelector.matchLabels['kubernetes.io/metadata.name'] == service_namespace | default('default')
+        fail_msg: "NetworkPolicy must target the workload namespace with ingress restricted to that namespace and default egress allowed."
 
     - name: Validate health probe commands
       ansible.builtin.assert:


### PR DESCRIPTION
## Summary
- add a shared `runtime_common` filter set and `service_context` macro so templates reuse security, secret, and mount normalisation
- restructure Docker, Podman, Kubernetes, Proxmox, and bare-metal templates to remove duplicated logic, support the unified `secrets.items` contract, and generate a default Kubernetes NetworkPolicy
- unify runtime secret preparation via a reusable Ansible task, extend schema and validation for the new fields, update policy/tests/docs, and refresh service samples

## Testing
- `pytest` *(fails: missing dependency jsonschema; repository dependencies could not be installed because pip cannot reach the proxy for ansible==9.5.1)*

------
https://chatgpt.com/codex/tasks/task_e_68f50aa6dbd0832ea586d7d68d9d69eb